### PR TITLE
feat: Exercise Max

### DIFF
--- a/magni/BEST_PRACTICES.md
+++ b/magni/BEST_PRACTICES.md
@@ -1,0 +1,170 @@
+# Best Practices - Magni (Frontend)
+
+Guidelines for building and extending the **Magni** React Native (Expo) frontend. This document is intended both as a reference for developers getting familiar with the codebase and as context for AI-assisted development prompts.
+
+---
+
+## Clean Code Principles
+
+Write code that is easy to read, understand, and maintain. Every function, component, and module should have a single, clear purpose.
+
+### Naming
+
+- Use **descriptive, intention-revealing names**. A reader should understand what a variable, function, or component does without needing to trace through its implementation.
+- Prefer full words over abbreviations (`workoutHistory` not `wkHist`, `isLoading` not `ld`).
+- Boolean variables and props should read as yes/no questions: `isVisible`, `hasError`, `canSubmit`.
+- Event handler props use an `on` prefix (`onSave`, `onDismiss`); internal handler functions use a `handle` prefix (`handleSave`, `handleDismiss`).
+
+### Functions and Components
+
+- Follow the **Single Responsibility Principle**. Each function should do one thing. Each component should render one conceptual piece of UI.
+- Keep functions short. If a function needs a comment explaining a section of its body, that section is a candidate for extraction into a named function.
+- Avoid deeply nested conditionals. Use early returns and guard clauses to keep the happy path unindented.
+- Prefer **pure functions** where possible. Given the same inputs, they should produce the same outputs with no side effects.
+
+### Code Organization
+
+- Keep files focused. A file that exports a component should contain that component and its closely related helpers — nothing more.
+- Order imports consistently: React/React Native, third-party libraries, internal modules (contexts, hooks, services, constants), then relative imports.
+- Co-locate types with the code that uses them. Shared domain types belong in `lib/models/`.
+
+---
+
+## Efficiency
+
+Write code that does exactly what is needed — no more, no less.
+
+- **Avoid unnecessary re-renders.** Use `React.memo`, `useMemo`, and `useCallback` where profiling shows a measurable benefit, but do not apply them prematurely or blanket-wrap every component.
+- **Minimize state.** Derive values from existing state rather than storing redundant copies. If a value can be computed from props or other state, compute it.
+- **Batch related state updates.** Group state that changes together into a single `useState` object or use `useReducer` when state transitions are complex.
+- **Avoid premature abstraction.** Do not generalize code until there is a real, demonstrated need. Duplication is cheaper than the wrong abstraction.
+- **Keep bundle size in check.** Import only what you need from libraries. Prefer lightweight alternatives when a heavy dependency is only partially used.
+
+---
+
+## Component Reusability
+
+Reuse components wherever possible and refactor existing components to be reusable where it makes sense. However, **reusability must not compromise readability**. A component that is technically reusable but difficult to understand or configure is worse than two simple, purpose-built components.
+
+### When to Extract a Reusable Component
+
+- The same visual pattern or interaction appears (or is about to appear) in **two or more places**.
+- An existing component has grown large and a clearly bounded section can stand on its own.
+- A piece of UI has a well-defined interface that can be expressed with a small number of props.
+
+### When NOT to Force Reusability
+
+- Two components look similar but serve fundamentally different purposes and are likely to diverge.
+- Making a component "generic" would require a sprawling props interface, excessive conditional logic, or render-prop gymnastics that obscure intent.
+- The abstraction only saves a few lines and adds indirection.
+
+### Guidelines
+
+- **Props over configuration objects.** Keep the component API flat and explicit. A reader should understand what a component does by scanning its props.
+- **Composition over inheritance.** Use `children` and render props to compose behavior rather than building deep component hierarchies.
+- **Sensible defaults.** Reusable components should work with minimal props. Optional props should have defaults that produce the most common behavior.
+- **Refactor incrementally.** When making an existing component reusable, do it in a separate commit so the refactor is reviewable on its own.
+
+---
+
+## Atomic and Small Components
+
+Components should be **small, focused, and composable**. Break down complex UIs into a tree of simple building blocks.
+
+- **One concern per component.** A component handles layout, *or* data fetching, *or* user interaction — not all three. Screen-level components compose smaller pieces; they should contain minimal logic themselves.
+- **Extract early.** If a component's render function is longer than roughly 80–100 lines, look for sections to extract. If a block of JSX is wrapped in a conditional or a `.map()`, it is almost always a candidate.
+- **Hooks for logic.** Move stateful logic, side effects, and data transformations into custom hooks. The component itself should primarily be concerned with rendering. See the existing hooks in `hooks/` (`useWorkoutData`, `useWorkoutForm`, `useWorkoutCompletion`, `useDailyStats`) for examples of this pattern.
+- **Flat component trees.** Avoid deeply nested wrapper components. If multiple layers of `<Wrapper>` exist solely to pass context or apply layout, flatten the structure or use composition.
+
+---
+
+## Styling
+
+All styling must align with the existing design system defined in `lib/constants/ui.ts`.
+
+### Design Tokens
+
+Use the established tokens for all visual properties:
+
+- **Colors:** Access through the `useThemeColors()` hook, which returns `LIGHT_COLORS` or `DARK_COLORS` depending on the user's preference. Never hard-code color values in component styles.
+- **Spacing:** Use `SPACING` constants (`xs` through `xxxl`) for margins, padding, and gaps.
+- **Typography:** Use `TYPOGRAPHY.sizes` and `TYPOGRAPHY.weights`. Do not introduce ad-hoc font sizes or weights.
+- **Border radius:** Use `BORDER_RADIUS` constants.
+- **Shadows:** Use `SHADOWS` presets (`sm`, `md`, `lg`).
+
+### Styling Conventions
+
+- Use `StyleSheet.create()` for static styles. Apply dynamic, theme-dependent overrides inline via the `style` prop.
+- Keep styles close to the component that uses them — defined at the bottom of the same file.
+- Avoid style objects that are dozens of properties long. If a style block is complex, consider whether the component should be broken down further.
+
+### New Tokens
+
+If a new feature needs a color, spacing value, or typographic style that does not exist in `ui.ts`, propose an addition to the design tokens rather than introducing a one-off value. New tokens should be intentional and broadly applicable.
+
+---
+
+## Responsive Design
+
+**Magni** runs on native mobile (iOS and Android) and web via Expo. Every component and screen must work well across these targets.
+
+- **Use flexbox.** React Native's layout engine is flexbox. Use `flex`, `flexDirection`, `alignItems`, and `justifyContent` for responsive layouts. Avoid fixed widths and heights except for intentionally fixed-size elements like icons or avatars.
+- **Respect platform differences.** Use `Platform.OS` checks sparingly and only when there is a genuine behavioral or visual difference that cannot be handled by flexbox or safe area insets alone.
+- **Safe areas.** Account for notches, status bars, and home indicators using `react-native-safe-area-context`.
+- **Scroll.** Any screen or section that may overflow must scroll. Use `ScrollView` or `FlatList` as appropriate — prefer `FlatList` for long or dynamic lists for performance.
+- **Test across targets.** Before considering a feature complete, verify it on web (the primary deployment target), and on at least one mobile form factor.
+
+---
+
+## Accessibility
+
+Every feature must be usable by people who rely on screen readers, keyboard navigation, or other assistive technologies. Accessibility is not a follow-up task — it is part of building the feature.
+
+### Core Requirements
+
+- **Label all interactive elements.** Every `TouchableOpacity`, `Pressable`, button, and input must have an `accessibilityLabel` that describes its purpose (e.g., `accessibilityLabel="Delete workout"`).
+- **Assign semantic roles.** Use `accessibilityRole` to communicate the element type: `"button"`, `"link"`, `"header"`, `"image"`, `"checkbox"`, etc.
+- **Communicate state.** Use `accessibilityState` for toggleable or stateful elements: `{ selected: true }`, `{ disabled: true }`, `{ checked: true }`.
+- **Group related content.** Use `accessible={true}` on container views that should be announced as a single unit.
+- **Announce dynamic changes.** When content changes in response to an action (e.g., a toast appearing, a form error surfacing), use `AccessibilityInfo.announceForAccessibility()` or `accessibilityLiveRegion="polite"` so screen readers notify the user.
+
+### Visual Accessibility
+
+- **Color contrast.** Text must meet a minimum contrast ratio of **4.5:1** against its background (WCAG AA). Use the existing theme colors, which are designed with contrast in mind.
+- **Touch targets.** Interactive elements should have a minimum size of **44×44 points** (Apple HIG) / **48×48 dp** (Material). Use `hitSlop` to increase the tappable area without affecting layout when the visual element is smaller.
+- **Do not rely on color alone** to convey meaning. Pair color indicators with text labels, icons, or patterns.
+
+### Keyboard and Focus
+
+- **Focusable elements.** Ensure all interactive elements are reachable via keyboard tab navigation on web.
+- **Focus order.** The tab order should follow visual reading order. Avoid using `tabIndex` to create non-obvious focus sequences.
+- **Visible focus indicators.** On web, interactive elements should have a clear focus ring or style change when focused via keyboard.
+
+---
+
+## Existing Patterns to Follow
+
+The codebase has established conventions that should be followed for consistency.
+
+| Pattern | Location | Usage |
+|---------|----------|-------|
+| **React Context** for global state | `contexts/` | Theme, auth, toasts, weight period. Wrap providers in `_layout.tsx`. |
+| **Custom hooks** for logic extraction | `hooks/` | Data fetching, form state, computed values. Components stay declarative. |
+| **Singleton services** for persistence | `lib/services/` | AsyncStorage operations, API calls. Access via `Service.getInstance()`. |
+| **Domain models** as TypeScript types | `lib/models/` | Shared type definitions for workouts, weight, averages. |
+| **Design tokens** for theming | `lib/constants/ui.ts` | Colors, spacing, typography, shadows, border radius. |
+| **Feature-based component folders** | `components/<feature>/` | Group related components by domain (workouts, weight, settings, auth). |
+| **Shared UI at components root** | `components/` | Cross-cutting UI: `Toast`, `ErrorBoundary`, `DatePickerModal`, confirmation system. |
+| **Thin route files** | `app/` | Route files compose feature components. They should contain minimal logic. |
+
+---
+
+## Summary
+
+1. Write clean, readable code with clear names and single-responsibility functions.
+2. Keep components small, atomic, and composable.
+3. Reuse components where a genuine pattern exists — do not force abstraction.
+4. Use the design system tokens in `lib/constants/ui.ts`; never hard-code visual values.
+5. Build every screen to work on web, iOS, and Android.
+6. Make every feature accessible from the start: labels, roles, contrast, touch targets.
+7. Follow established project patterns for state, services, and file organization.

--- a/magni/__tests__/lib/models/ExerciseMax.test.ts
+++ b/magni/__tests__/lib/models/ExerciseMax.test.ts
@@ -1,0 +1,286 @@
+import {
+  ExerciseMax,
+  ExerciseMaxConverter,
+  ExerciseMaxValidator,
+  EXERCISE_MAX_CONSTRAINTS,
+  calculateE1RM,
+  calculateWorkingWeight,
+} from '../../../lib/models/ExerciseMax'
+
+describe('ExerciseMax Model', () => {
+  describe('ExerciseMax Interface', () => {
+    it('has correct structure', () => {
+      const exerciseMax: ExerciseMax = {
+        id: 'test-id',
+        name: 'Squat',
+        maxWeight: 300,
+        lastUpdated: '2026-03-26',
+      }
+
+      expect(exerciseMax).toHaveProperty('id')
+      expect(exerciseMax).toHaveProperty('name')
+      expect(exerciseMax).toHaveProperty('maxWeight')
+      expect(exerciseMax).toHaveProperty('lastUpdated')
+
+      expect(typeof exerciseMax.id).toBe('string')
+      expect(typeof exerciseMax.name).toBe('string')
+      expect(typeof exerciseMax.maxWeight).toBe('number')
+      expect(typeof exerciseMax.lastUpdated).toBe('string')
+    })
+  })
+
+  describe('ExerciseMaxConverter', () => {
+    describe('toData', () => {
+      it('converts ExerciseMax to data correctly', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'test-id',
+          name: 'Bench Press',
+          maxWeight: 225,
+          lastUpdated: '2026-03-26',
+        }
+
+        const data = ExerciseMaxConverter.toData(exerciseMax)
+
+        expect(data.id).toBe(exerciseMax.id)
+        expect(data.name).toBe(exerciseMax.name)
+        expect(data.maxWeight).toBe(exerciseMax.maxWeight)
+        expect(data.lastUpdated).toBe(exerciseMax.lastUpdated)
+      })
+    })
+
+    describe('fromData', () => {
+      it('converts data to ExerciseMax correctly', () => {
+        const data: ExerciseMax = {
+          id: 'test-id',
+          name: 'Deadlift',
+          maxWeight: 405,
+          lastUpdated: '2026-03-26',
+        }
+
+        const exerciseMax = ExerciseMaxConverter.fromData(data)
+
+        expect(exerciseMax.id).toBe(data.id)
+        expect(exerciseMax.name).toBe(data.name)
+        expect(exerciseMax.maxWeight).toBe(data.maxWeight)
+        expect(exerciseMax.lastUpdated).toBe(data.lastUpdated)
+      })
+    })
+
+    describe('Round-trip conversion', () => {
+      it('maintains data integrity through conversion cycle', () => {
+        const original: ExerciseMax = {
+          id: 'round-trip-id',
+          name: 'Squat',
+          maxWeight: 315,
+          lastUpdated: '2026-01-15',
+        }
+
+        const converted = ExerciseMaxConverter.fromData(ExerciseMaxConverter.toData(original))
+
+        expect(converted.id).toBe(original.id)
+        expect(converted.name).toBe(original.name)
+        expect(converted.maxWeight).toBe(original.maxWeight)
+        expect(converted.lastUpdated).toBe(original.lastUpdated)
+      })
+    })
+  })
+
+  describe('ExerciseMaxValidator', () => {
+    describe('validate', () => {
+      it('validates exercise max with valid data', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'valid-id',
+          name: 'Squat',
+          maxWeight: 300,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).not.toThrow()
+      })
+
+      it('throws error for empty name', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'invalid-id',
+          name: '',
+          maxWeight: 300,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).toThrow('Exercise name is required.')
+      })
+
+      it('throws error for whitespace-only name', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'invalid-id',
+          name: '   ',
+          maxWeight: 300,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).toThrow('Exercise name is required.')
+      })
+
+      it('throws error for name exceeding length limit', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'invalid-id',
+          name: 'A'.repeat(EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT + 1),
+          maxWeight: 300,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).toThrow(
+          `Exercise name cannot exceed ${EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT} characters.`,
+        )
+      })
+
+      it('throws error for negative max weight', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'invalid-id',
+          name: 'Squat',
+          maxWeight: -100,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).toThrow('Max weight cannot be negative.')
+      })
+
+      it('throws error for max weight exceeding limit', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'invalid-id',
+          name: 'Squat',
+          maxWeight: EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT + 1,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).toThrow(
+          `Max weight cannot exceed ${EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT}.`,
+        )
+      })
+
+      it('allows maximum valid values', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'max-valid-id',
+          name: 'A'.repeat(EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT),
+          maxWeight: EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).not.toThrow()
+      })
+
+      it('allows zero max weight', () => {
+        const exerciseMax: ExerciseMax = {
+          id: 'zero-weight',
+          name: 'Squat',
+          maxWeight: 0,
+          lastUpdated: '2026-03-26',
+        }
+
+        expect(() => ExerciseMaxValidator.validate(exerciseMax)).not.toThrow()
+      })
+    })
+  })
+
+  describe('EXERCISE_MAX_CONSTRAINTS', () => {
+    it('has correct constraint values', () => {
+      expect(EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT).toBe(100)
+      expect(EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT).toBe(9999)
+      expect(EXERCISE_MAX_CONSTRAINTS.AMRAP_REPS_LIMIT).toBe(100)
+    })
+  })
+
+  describe('calculateE1RM', () => {
+    it('calculates e1RM correctly using Epley formula', () => {
+      // e1RM = weight * (1 + reps / 30)
+      // 200 * (1 + 10/30) = 200 * 1.333... = 266.66... → 267
+      expect(calculateE1RM(200, 10)).toBe(267)
+    })
+
+    it('returns the weight itself for a single rep', () => {
+      expect(calculateE1RM(300, 1)).toBe(300)
+    })
+
+    it('calculates correctly for 5 reps', () => {
+      // 225 * (1 + 5/30) = 225 * 1.1667 = 262.5 → 263
+      expect(calculateE1RM(225, 5)).toBe(263)
+    })
+
+    it('calculates correctly for 3 reps', () => {
+      // 315 * (1 + 3/30) = 315 * 1.1 = 346.5 → 347
+      expect(calculateE1RM(315, 3)).toBe(347)
+    })
+
+    it('calculates correctly for high reps', () => {
+      // 135 * (1 + 20/30) = 135 * 1.6667 = 225 → 225
+      expect(calculateE1RM(135, 20)).toBe(225)
+    })
+
+    it('returns 0 for zero weight', () => {
+      expect(calculateE1RM(0, 10)).toBe(0)
+    })
+
+    it('returns 0 for zero reps', () => {
+      expect(calculateE1RM(200, 0)).toBe(0)
+    })
+
+    it('returns 0 for negative weight', () => {
+      expect(calculateE1RM(-100, 5)).toBe(0)
+    })
+
+    it('returns 0 for negative reps', () => {
+      expect(calculateE1RM(200, -5)).toBe(0)
+    })
+
+    it('rounds to nearest whole number', () => {
+      // 100 * (1 + 7/30) = 100 * 1.2333... = 123.33... → 123
+      expect(calculateE1RM(100, 7)).toBe(123)
+    })
+  })
+
+  describe('calculateWorkingWeight', () => {
+    it('calculates working weight from max and percentage', () => {
+      // 300 * 75 / 100 = 225
+      expect(calculateWorkingWeight(300, 75)).toBe(225)
+    })
+
+    it('calculates 100% correctly', () => {
+      expect(calculateWorkingWeight(315, 100)).toBe(315)
+    })
+
+    it('calculates 50% correctly', () => {
+      // 400 * 50 / 100 = 200
+      expect(calculateWorkingWeight(400, 50)).toBe(200)
+    })
+
+    it('rounds to nearest whole number', () => {
+      // 315 * 67 / 100 = 211.05 → 211
+      expect(calculateWorkingWeight(315, 67)).toBe(211)
+    })
+
+    it('handles rounding up correctly', () => {
+      // 300 * 85 / 100 = 255
+      expect(calculateWorkingWeight(300, 85)).toBe(255)
+    })
+
+    it('returns 0 for zero max weight', () => {
+      expect(calculateWorkingWeight(0, 75)).toBe(0)
+    })
+
+    it('returns 0 for zero percentage', () => {
+      expect(calculateWorkingWeight(300, 0)).toBe(0)
+    })
+
+    it('returns 0 for negative max weight', () => {
+      expect(calculateWorkingWeight(-300, 75)).toBe(0)
+    })
+
+    it('returns 0 for negative percentage', () => {
+      expect(calculateWorkingWeight(300, -75)).toBe(0)
+    })
+
+    it('handles percentages over 100', () => {
+      // 200 * 110 / 100 = 220
+      expect(calculateWorkingWeight(200, 110)).toBe(220)
+    })
+  })
+})

--- a/magni/__tests__/lib/services/ExerciseMaxService.test.ts
+++ b/magni/__tests__/lib/services/ExerciseMaxService.test.ts
@@ -1,0 +1,331 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { exerciseMaxService } from '../../../lib/services/ExerciseMaxService'
+import { ExerciseMax } from '../../../lib/models/ExerciseMax'
+
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+    select: jest.fn((obj: any) => obj.ios),
+  },
+}))
+
+const createMockExerciseMax = (overrides?: Partial<ExerciseMax>): ExerciseMax => ({
+  id: 'test-id',
+  name: 'Squat',
+  maxWeight: 300,
+  lastUpdated: '2026-03-26',
+  ...overrides,
+})
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>
+const mockGetItem = mockAsyncStorage.getItem as jest.MockedFunction<typeof mockAsyncStorage.getItem>
+const mockSetItem = mockAsyncStorage.setItem as jest.MockedFunction<typeof mockAsyncStorage.setItem>
+
+const originalConsoleError = console.error
+beforeAll(() => {
+  console.error = jest.fn()
+})
+
+afterAll(() => {
+  console.error = originalConsoleError
+})
+
+describe('ExerciseMaxService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getExerciseMaxes', () => {
+    it('returns empty array when no data exists', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      const result = await exerciseMaxService.getExerciseMaxes()
+      expect(result).toEqual([])
+      expect(mockGetItem).toHaveBeenCalledWith('exercise_maxes')
+    })
+
+    it('returns empty array when storage throws error', async () => {
+      mockGetItem.mockRejectedValueOnce(new Error('Storage error'))
+      const result = await exerciseMaxService.getExerciseMaxes()
+      expect(result).toEqual([])
+    })
+
+    it('returns exercise maxes from storage', async () => {
+      const mockData: ExerciseMax[] = [
+        createMockExerciseMax({ id: 'squat-1', name: 'Squat', maxWeight: 300 }),
+        createMockExerciseMax({ id: 'bench-1', name: 'Bench Press', maxWeight: 225 }),
+        createMockExerciseMax({ id: 'deadlift-1', name: 'Deadlift', maxWeight: 405 }),
+      ]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(mockData))
+
+      const result = await exerciseMaxService.getExerciseMaxes()
+
+      expect(result).toHaveLength(3)
+      expect(result[0].name).toBe('Squat')
+      expect(result[1].name).toBe('Bench Press')
+      expect(result[2].name).toBe('Deadlift')
+    })
+
+    it('handles malformed JSON gracefully', async () => {
+      mockGetItem.mockResolvedValueOnce('invalid json')
+      const result = await exerciseMaxService.getExerciseMaxes()
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getExerciseMaxById', () => {
+    it('returns the exercise max when found', async () => {
+      const mockData: ExerciseMax[] = [
+        createMockExerciseMax({ id: 'squat-1', name: 'Squat' }),
+        createMockExerciseMax({ id: 'bench-1', name: 'Bench Press' }),
+      ]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(mockData))
+
+      const result = await exerciseMaxService.getExerciseMaxById('squat-1')
+
+      expect(result).toBeDefined()
+      expect(result!.name).toBe('Squat')
+    })
+
+    it('returns undefined when not found', async () => {
+      const mockData: ExerciseMax[] = [
+        createMockExerciseMax({ id: 'squat-1', name: 'Squat' }),
+      ]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(mockData))
+
+      const result = await exerciseMaxService.getExerciseMaxById('nonexistent')
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined when storage throws error', async () => {
+      mockGetItem.mockRejectedValueOnce(new Error('Storage error'))
+
+      const result = await exerciseMaxService.getExerciseMaxById('any-id')
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('createExerciseMax', () => {
+    it('creates exercise max successfully', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const newMax = createMockExerciseMax({
+        id: 'new-squat',
+        name: 'Squat',
+        maxWeight: 315,
+      })
+
+      const result = await exerciseMaxService.createExerciseMax(newMax)
+
+      expect(result).toBe(true)
+      expect(mockSetItem).toHaveBeenCalledWith(
+        'exercise_maxes',
+        expect.any(String),
+      )
+
+      const storedData = JSON.parse(mockSetItem.mock.calls[0][1] as string)
+      expect(storedData).toHaveLength(1)
+      expect(storedData[0].id).toBe('new-squat')
+      expect(storedData[0].maxWeight).toBe(315)
+    })
+
+    it('prepends new max to existing maxes', async () => {
+      const existingMax = createMockExerciseMax({ id: 'existing-1', name: 'Bench Press' })
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify([existingMax]))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const newMax = createMockExerciseMax({ id: 'new-1', name: 'Squat' })
+
+      await exerciseMaxService.createExerciseMax(newMax)
+
+      const storedData = JSON.parse(mockSetItem.mock.calls[0][1] as string)
+      expect(storedData).toHaveLength(2)
+      expect(storedData[0].id).toBe('new-1')
+      expect(storedData[1].id).toBe('existing-1')
+    })
+
+    it('returns false when validation fails', async () => {
+      const invalidMax = createMockExerciseMax({
+        name: '',
+      })
+
+      const result = await exerciseMaxService.createExerciseMax(invalidMax)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when storage fails', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      mockSetItem.mockRejectedValueOnce(new Error('Storage error'))
+
+      const newMax = createMockExerciseMax()
+
+      const result = await exerciseMaxService.createExerciseMax(newMax)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when max weight exceeds limit', async () => {
+      const invalidMax = createMockExerciseMax({
+        maxWeight: 10000,
+      })
+
+      const result = await exerciseMaxService.createExerciseMax(invalidMax)
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('updateExerciseMax', () => {
+    it('updates exercise max successfully', async () => {
+      const existingMaxes = [
+        createMockExerciseMax({ id: 'update-1', maxWeight: 300 }),
+        createMockExerciseMax({ id: 'keep-1', maxWeight: 225 }),
+      ]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(existingMaxes))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const updatedMax = createMockExerciseMax({
+        id: 'update-1',
+        maxWeight: 315,
+        name: 'Squat (Updated)',
+      })
+
+      const result = await exerciseMaxService.updateExerciseMax(updatedMax)
+
+      expect(result).toBe(true)
+
+      const storedData = JSON.parse(mockSetItem.mock.calls[0][1] as string)
+      const updatedItem = storedData.find((m: ExerciseMax) => m.id === 'update-1')
+      expect(updatedItem.maxWeight).toBe(315)
+      expect(updatedItem.name).toBe('Squat (Updated)')
+
+      const unchangedItem = storedData.find((m: ExerciseMax) => m.id === 'keep-1')
+      expect(unchangedItem.maxWeight).toBe(225)
+    })
+
+    it('returns false when validation fails', async () => {
+      const invalidMax = createMockExerciseMax({
+        id: 'test-1',
+        maxWeight: -100,
+      })
+
+      const result = await exerciseMaxService.updateExerciseMax(invalidMax)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when storage fails', async () => {
+      mockGetItem.mockResolvedValueOnce(JSON.stringify([createMockExerciseMax({ id: 'test-1' })]))
+      mockSetItem.mockRejectedValueOnce(new Error('Set item error'))
+
+      const updatedMax = createMockExerciseMax({ id: 'test-1', maxWeight: 400 })
+
+      const result = await exerciseMaxService.updateExerciseMax(updatedMax)
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('removeExerciseMax', () => {
+    it('removes exercise max successfully', async () => {
+      const existingMaxes = [
+        createMockExerciseMax({ id: 'keep-1', name: 'Squat' }),
+        createMockExerciseMax({ id: 'remove-1', name: 'Bench Press' }),
+        createMockExerciseMax({ id: 'keep-2', name: 'Deadlift' }),
+      ]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(existingMaxes))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const result = await exerciseMaxService.removeExerciseMax('remove-1')
+
+      expect(result).toBe(true)
+
+      const storedData = JSON.parse(mockSetItem.mock.calls[0][1] as string)
+      expect(storedData).toHaveLength(2)
+      expect(storedData.find((m: ExerciseMax) => m.id === 'remove-1')).toBeUndefined()
+      expect(storedData.find((m: ExerciseMax) => m.id === 'keep-1')).toBeDefined()
+      expect(storedData.find((m: ExerciseMax) => m.id === 'keep-2')).toBeDefined()
+    })
+
+    it('returns true even when exercise max does not exist', async () => {
+      const existingMaxes = [createMockExerciseMax({ id: 'keep-1' })]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(existingMaxes))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const result = await exerciseMaxService.removeExerciseMax('non-existent')
+
+      expect(result).toBe(true)
+
+      const storedData = JSON.parse(mockSetItem.mock.calls[0][1] as string)
+      expect(storedData).toHaveLength(1)
+    })
+
+    it('returns false when storage fails', async () => {
+      mockGetItem.mockResolvedValueOnce(JSON.stringify([createMockExerciseMax({ id: 'test-1' })]))
+      mockSetItem.mockRejectedValueOnce(new Error('Set item error'))
+
+      const result = await exerciseMaxService.removeExerciseMax('test-1')
+
+      expect(result).toBe(false)
+    })
+
+    it('succeeds when getExerciseMaxes fails but setItem succeeds', async () => {
+      mockGetItem.mockRejectedValueOnce(new Error('Storage error'))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const result = await exerciseMaxService.removeExerciseMax('any-id')
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('Singleton Pattern', () => {
+    it('returns the same instance', () => {
+      const instance1 = exerciseMaxService
+      const instance2 = exerciseMaxService
+      expect(instance1).toBe(instance2)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('handles max weight at the limit', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const maxAtLimit = createMockExerciseMax({
+        maxWeight: 9999,
+      })
+
+      const result = await exerciseMaxService.createExerciseMax(maxAtLimit)
+      expect(result).toBe(true)
+
+      const storedData = JSON.parse(mockSetItem.mock.calls[0][1] as string)
+      expect(storedData[0].maxWeight).toBe(9999)
+    })
+
+    it('handles zero max weight', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const zeroMax = createMockExerciseMax({
+        maxWeight: 0,
+      })
+
+      const result = await exerciseMaxService.createExerciseMax(zeroMax)
+      expect(result).toBe(true)
+
+      const storedData = JSON.parse(mockSetItem.mock.calls[0][1] as string)
+      expect(storedData[0].maxWeight).toBe(0)
+    })
+  })
+})

--- a/magni/app/settings.tsx
+++ b/magni/app/settings.tsx
@@ -12,6 +12,7 @@ import AppearanceSection from '../components/settings/AppearanceSection'
 import WeightPeriodSection from '../components/settings/WeightPeriodSection'
 import SupportSection from '../components/settings/SupportSection'
 import AuthSection from '../components/settings/AuthSection'
+import ExerciseMaxSection from '../components/settings/ExerciseMaxSection'
 import ClearHistoryModal from '../components/settings/ClearHistoryModal'
 import ImportConfirmModal from '../components/settings/ImportConfirmModal'
 import { useWeightPeriod } from '../contexts/WeightPeriodContext'
@@ -121,6 +122,8 @@ export default function SettingsScreen() {
           onExport={handleExportWorkouts}
           onFileSelected={handleFileSelected}
         />
+
+        <ExerciseMaxSection />
 
         <AppearanceSection
           themeMode={themeMode}

--- a/magni/components/settings/ExerciseMaxFormModal.tsx
+++ b/magni/components/settings/ExerciseMaxFormModal.tsx
@@ -1,0 +1,423 @@
+import React, { useState, useEffect } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  TouchableOpacity,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native'
+import { ExerciseMax, calculateE1RM, EXERCISE_MAX_CONSTRAINTS } from '../../lib/models/ExerciseMax'
+import { exerciseMaxService } from '../../lib/services/ExerciseMaxService'
+import { useThemeColors } from '../../hooks/useThemeColors'
+import { SPACING, TYPOGRAPHY, BORDER_RADIUS } from '../../lib/constants/ui'
+
+interface ExerciseMaxFormModalProps {
+  visible: boolean;
+  exerciseMax?: ExerciseMax;
+  onSave: (exerciseMax: ExerciseMax) => void;
+  onCancel: () => void;
+}
+
+export default function ExerciseMaxFormModal({
+  visible,
+  exerciseMax,
+  onSave,
+  onCancel,
+}: ExerciseMaxFormModalProps) {
+  const colors = useThemeColors()
+
+  const [name, setName] = useState('')
+  const [maxWeight, setMaxWeight] = useState('')
+  const [amrapWeight, setAmrapWeight] = useState('')
+  const [amrapReps, setAmrapReps] = useState('')
+  const [showAmrapCalc, setShowAmrapCalc] = useState(false)
+  const [errors, setErrors] = useState<{ name?: string; maxWeight?: string; amrapWeight?: string; amrapReps?: string }>({})
+
+  useEffect(() => {
+    if (exerciseMax) {
+      setName(exerciseMax.name)
+      setMaxWeight(exerciseMax.maxWeight.toString())
+    } else {
+      setName('')
+      setMaxWeight('')
+    }
+    setAmrapWeight('')
+    setAmrapReps('')
+    setShowAmrapCalc(false)
+    setErrors({})
+  }, [exerciseMax, visible])
+
+  const estimatedMax = calculateE1RM(Number(amrapWeight) || 0, Number(amrapReps) || 0)
+
+  const handleApplyAmrap = () => {
+    const w = Number(amrapWeight)
+    const r = Number(amrapReps)
+    const newErrors: typeof errors = {}
+
+    if (isNaN(w) || w <= 0) {
+      newErrors.amrapWeight = 'Enter a valid weight'
+    }
+    if (isNaN(r) || r <= 0 || !Number.isInteger(r)) {
+      newErrors.amrapReps = 'Enter a valid rep count'
+    }
+    if (r > EXERCISE_MAX_CONSTRAINTS.AMRAP_REPS_LIMIT) {
+      newErrors.amrapReps = `Reps cannot exceed ${EXERCISE_MAX_CONSTRAINTS.AMRAP_REPS_LIMIT}`
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(prev => ({ ...prev, ...newErrors }))
+      return
+    }
+
+    setMaxWeight(estimatedMax.toString())
+    setShowAmrapCalc(false)
+    setErrors({})
+  }
+
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {}
+
+    if (!name.trim()) {
+      newErrors.name = 'Exercise name is required'
+    }
+    if (name.length > EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT) {
+      newErrors.name = `Name cannot exceed ${EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT} characters`
+    }
+
+    const weightNum = Number(maxWeight)
+    if (maxWeight === '' || isNaN(weightNum) || weightNum <= 0) {
+      newErrors.maxWeight = 'Enter a valid max weight'
+    }
+    if (weightNum > EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT) {
+      newErrors.maxWeight = `Weight cannot exceed ${EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT}`
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = async () => {
+    if (!validateForm()) return
+
+    const data: ExerciseMax = {
+      id: exerciseMax?.id || Date.now().toString(),
+      name: name.trim(),
+      maxWeight: Number(maxWeight),
+      lastUpdated: new Date().toISOString().split('T')[0],
+    }
+
+    const success = exerciseMax
+      ? await exerciseMaxService.updateExerciseMax(data)
+      : await exerciseMaxService.createExerciseMax(data)
+
+    if (success) {
+      onSave(data)
+    }
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onCancel}
+    >
+      <View style={styles.overlay}>
+        <KeyboardAvoidingView
+          style={styles.keyboardView}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
+          <View style={[styles.container, { backgroundColor: colors.background }]}>
+            <View style={[styles.header, { borderBottomColor: colors.border }]}>
+              <Text style={[styles.title, { color: colors.text.primary }]}>
+                {exerciseMax ? 'Edit Exercise Max' : 'Add Exercise Max'}
+              </Text>
+              <TouchableOpacity
+                onPress={onCancel}
+                style={styles.closeButton}
+                accessibilityLabel="Close"
+                accessibilityRole="button"
+              >
+                <Text style={[styles.closeText, { color: colors.text.secondary }]}>✕</Text>
+              </TouchableOpacity>
+            </View>
+
+            <ScrollView style={styles.body} showsVerticalScrollIndicator={false}>
+              <View style={styles.field}>
+                <Text style={[styles.label, { color: colors.text.primary }]}>Exercise Name</Text>
+                <TextInput
+                  style={[styles.input, {
+                    backgroundColor: colors.surface,
+                    color: colors.text.primary,
+                    borderColor: errors.name ? '#ff4444' : colors.border,
+                  }]}
+                  value={name}
+                  onChangeText={(text) => {
+                    setName(text)
+                    if (errors.name) setErrors(prev => ({ ...prev, name: undefined }))
+                  }}
+                  placeholder="Exercise Name"
+                  placeholderTextColor={colors.text.tertiary}
+                  accessibilityLabel="Exercise name"
+                />
+                {errors.name && <Text style={styles.errorText}>{errors.name}</Text>}
+              </View>
+
+              <View style={styles.field}>
+                <Text style={[styles.label, { color: colors.text.primary }]}>1 Rep Max</Text>
+                <TextInput
+                  style={[styles.input, {
+                    backgroundColor: colors.surface,
+                    color: colors.text.primary,
+                    borderColor: errors.maxWeight ? '#ff4444' : colors.border,
+                  }]}
+                  value={maxWeight}
+                  onChangeText={(text) => {
+                    setMaxWeight(text)
+                    if (errors.maxWeight) setErrors(prev => ({ ...prev, maxWeight: undefined }))
+                  }}
+                  placeholder="0"
+                  placeholderTextColor={colors.text.tertiary}
+                  keyboardType="numeric"
+                  accessibilityLabel="One rep max weight"
+                />
+                {errors.maxWeight && <Text style={styles.errorText}>{errors.maxWeight}</Text>}
+              </View>
+
+              <TouchableOpacity
+                style={[styles.amrapToggle, { borderColor: colors.border }]}
+                onPress={() => setShowAmrapCalc(!showAmrapCalc)}
+                accessibilityLabel="Estimate from AMRAP set"
+                accessibilityRole="button"
+              >
+                <Text style={[styles.amrapToggleText, { color: colors.primary }]}>
+                  {showAmrapCalc ? 'Hide AMRAP Calculator' : 'Estimate from AMRAP'}
+                </Text>
+              </TouchableOpacity>
+
+              {showAmrapCalc && (
+                <View style={[styles.amrapSection, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+                  <Text style={[styles.amrapDescription, { color: colors.text.secondary }]}>
+                    Enter the weight and reps from an AMRAP set to estimate your 1RM.
+                  </Text>
+
+                  <View style={styles.amrapRow}>
+                    <View style={styles.amrapField}>
+                      <Text style={[styles.label, { color: colors.text.primary }]}>Weight</Text>
+                      <TextInput
+                        style={[styles.input, {
+                          backgroundColor: colors.background,
+                          color: colors.text.primary,
+                          borderColor: errors.amrapWeight ? '#ff4444' : colors.border,
+                        }]}
+                        value={amrapWeight}
+                        onChangeText={(text) => {
+                          setAmrapWeight(text)
+                          if (errors.amrapWeight) setErrors(prev => ({ ...prev, amrapWeight: undefined }))
+                        }}
+                        placeholder="0"
+                        placeholderTextColor={colors.text.tertiary}
+                        keyboardType="numeric"
+                        accessibilityLabel="AMRAP weight"
+                      />
+                      {errors.amrapWeight && <Text style={styles.errorText}>{errors.amrapWeight}</Text>}
+                    </View>
+
+                    <View style={styles.amrapField}>
+                      <Text style={[styles.label, { color: colors.text.primary }]}>Reps</Text>
+                      <TextInput
+                        style={[styles.input, {
+                          backgroundColor: colors.background,
+                          color: colors.text.primary,
+                          borderColor: errors.amrapReps ? '#ff4444' : colors.border,
+                        }]}
+                        value={amrapReps}
+                        onChangeText={(text) => {
+                          setAmrapReps(text)
+                          if (errors.amrapReps) setErrors(prev => ({ ...prev, amrapReps: undefined }))
+                        }}
+                        placeholder="0"
+                        placeholderTextColor={colors.text.tertiary}
+                        keyboardType="numeric"
+                        accessibilityLabel="AMRAP reps"
+                      />
+                      {errors.amrapReps && <Text style={styles.errorText}>{errors.amrapReps}</Text>}
+                    </View>
+                  </View>
+
+                  {estimatedMax > 0 && (
+                    <Text style={[styles.estimatedMax, { color: colors.text.primary }]}>
+                      Estimated 1RM: <Text style={{ fontWeight: TYPOGRAPHY.weights.bold }}>{estimatedMax}</Text>
+                    </Text>
+                  )}
+
+                  <TouchableOpacity
+                    style={[styles.applyButton, { backgroundColor: colors.primary }]}
+                    onPress={handleApplyAmrap}
+                    accessibilityLabel="Apply estimated max"
+                    accessibilityRole="button"
+                  >
+                    <Text style={styles.applyButtonText}>Apply Estimate</Text>
+                  </TouchableOpacity>
+                </View>
+              )}
+
+              <View style={styles.actions}>
+                <TouchableOpacity
+                  style={[styles.cancelButton, { borderColor: colors.border }]}
+                  onPress={onCancel}
+                  accessibilityLabel="Cancel"
+                  accessibilityRole="button"
+                >
+                  <Text style={[styles.cancelButtonText, { color: colors.text.primary }]}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.saveButton, { backgroundColor: colors.primary }]}
+                  onPress={handleSave}
+                  accessibilityLabel={exerciseMax ? 'Update exercise max' : 'Save exercise max'}
+                  accessibilityRole="button"
+                >
+                  <Text style={styles.saveButtonText}>{exerciseMax ? 'Update' : 'Save'}</Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  keyboardView: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  container: {
+    borderTopLeftRadius: BORDER_RADIUS.xl,
+    borderTopRightRadius: BORDER_RADIUS.xl,
+    maxHeight: '90%',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: TYPOGRAPHY.sizes.lg,
+    fontWeight: TYPOGRAPHY.weights.bold,
+  },
+  closeButton: {
+    padding: SPACING.sm,
+  },
+  closeText: {
+    fontSize: TYPOGRAPHY.sizes.lg,
+  },
+  body: {
+    padding: SPACING.lg,
+  },
+  field: {
+    marginBottom: SPACING.lg,
+  },
+  label: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+    marginBottom: SPACING.sm,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    fontSize: TYPOGRAPHY.sizes.md,
+  },
+  errorText: {
+    color: '#ff4444',
+    fontSize: TYPOGRAPHY.sizes.xs,
+    marginTop: SPACING.xs,
+  },
+  amrapToggle: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderWidth: 1,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.lg,
+  },
+  amrapToggleText: {
+    fontSize: TYPOGRAPHY.sizes.sm,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+  },
+  amrapSection: {
+    padding: SPACING.md,
+    borderWidth: 1,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: SPACING.lg,
+  },
+  amrapDescription: {
+    fontSize: TYPOGRAPHY.sizes.sm,
+    marginBottom: SPACING.md,
+  },
+  amrapRow: {
+    flexDirection: 'row',
+    gap: SPACING.md,
+  },
+  amrapField: {
+    flex: 1,
+    marginBottom: SPACING.sm,
+  },
+  estimatedMax: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    marginTop: SPACING.sm,
+    marginBottom: SPACING.sm,
+  },
+  applyButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    marginTop: SPACING.xs,
+  },
+  applyButtonText: {
+    color: '#fff',
+    fontSize: TYPOGRAPHY.sizes.sm,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginTop: SPACING.xl,
+    paddingBottom: SPACING.xxxl,
+  },
+  cancelButton: {
+    paddingHorizontal: SPACING.xxxl,
+    paddingVertical: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+  },
+  cancelButtonText: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+  },
+  saveButton: {
+    paddingHorizontal: SPACING.xxxl,
+    paddingVertical: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+  },
+  saveButtonText: {
+    color: '#fff',
+    fontSize: TYPOGRAPHY.sizes.md,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+  },
+})

--- a/magni/components/settings/ExerciseMaxSection.tsx
+++ b/magni/components/settings/ExerciseMaxSection.tsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { Text, View, StyleSheet, TouchableOpacity } from 'react-native'
+import { ExerciseMax } from '../../lib/models/ExerciseMax'
+import { exerciseMaxService } from '../../lib/services/ExerciseMaxService'
+import { useThemeColors } from '../../hooks/useThemeColors'
+import { confirmDelete } from '../../utils/confirm'
+import ExerciseMaxFormModal from './ExerciseMaxFormModal'
+import { SPACING, TYPOGRAPHY, BORDER_RADIUS, SHADOWS } from '../../lib/constants/ui'
+
+export default function ExerciseMaxSection() {
+  const colors = useThemeColors()
+  const [maxes, setMaxes] = useState<ExerciseMax[]>([])
+  const [showForm, setShowForm] = useState(false)
+  const [editingMax, setEditingMax] = useState<ExerciseMax | undefined>(undefined)
+
+  const loadMaxes = useCallback(async () => {
+    const data = await exerciseMaxService.getExerciseMaxes()
+    setMaxes(data)
+  }, [])
+
+  useEffect(() => {
+    loadMaxes()
+  }, [loadMaxes])
+
+  const handleAdd = () => {
+    setEditingMax(undefined)
+    setShowForm(true)
+  }
+
+  const handleEdit = (exerciseMax: ExerciseMax) => {
+    setEditingMax(exerciseMax)
+    setShowForm(true)
+  }
+
+  const handleDelete = (exerciseMax: ExerciseMax) => {
+    confirmDelete(
+      'Delete Exercise Max',
+      `Are you sure you want to delete the max for "${exerciseMax.name}"?`,
+      async () => {
+        await exerciseMaxService.removeExerciseMax(exerciseMax.id)
+        loadMaxes()
+      },
+    )
+  }
+
+  const handleSave = () => {
+    setShowForm(false)
+    setEditingMax(undefined)
+    loadMaxes()
+  }
+
+  const handleCancel = () => {
+    setShowForm(false)
+    setEditingMax(undefined)
+  }
+
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>Exercise Maxes</Text>
+
+      {maxes.length === 0 ? (
+        <View style={[styles.emptyState, { backgroundColor: colors.surface }]}>
+          <Text style={[styles.emptyText, { color: colors.text.secondary }]}>
+            No exercise maxes set. Add your squat, bench, or deadlift max to use percentage-based programming.
+          </Text>
+        </View>
+      ) : (
+        maxes.map((exerciseMax) => (
+          <View
+            key={exerciseMax.id}
+            style={[styles.maxItem, { backgroundColor: colors.surface }]}
+          >
+            <TouchableOpacity
+              style={styles.maxContent}
+              onPress={() => handleEdit(exerciseMax)}
+              accessibilityLabel={`Edit ${exerciseMax.name} max`}
+              accessibilityRole="button"
+            >
+              <Text style={[styles.maxName, { color: colors.text.primary }]}>{exerciseMax.name}</Text>
+              <Text style={[styles.maxWeight, { color: colors.text.secondary }]}>
+                {exerciseMax.maxWeight} lbs
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => handleDelete(exerciseMax)}
+              style={styles.deleteButton}
+              accessibilityLabel={`Delete ${exerciseMax.name} max`}
+              accessibilityRole="button"
+            >
+              <Text style={[styles.deleteText, { color: colors.error || '#FF3B30' }]}>✕</Text>
+            </TouchableOpacity>
+          </View>
+        ))
+      )}
+
+      <TouchableOpacity
+        style={[styles.addButton, { borderColor: colors.border }]}
+        onPress={handleAdd}
+        accessibilityLabel="Add exercise max"
+        accessibilityRole="button"
+      >
+        <Text style={[styles.addButtonText, { color: colors.primary }]}>+ Add Exercise Max</Text>
+      </TouchableOpacity>
+
+      <ExerciseMaxFormModal
+        visible={showForm}
+        exerciseMax={editingMax}
+        onSave={handleSave}
+        onCancel={handleCancel}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  emptyState: {
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: 1,
+    ...SHADOWS.sm,
+  },
+  emptyText: {
+    fontSize: TYPOGRAPHY.sizes.sm,
+    lineHeight: 20,
+  },
+  maxItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    marginBottom: 1,
+    ...SHADOWS.sm,
+  },
+  maxContent: {
+    flex: 1,
+  },
+  maxName: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    fontWeight: TYPOGRAPHY.weights.medium,
+    marginBottom: 2,
+  },
+  maxWeight: {
+    fontSize: TYPOGRAPHY.sizes.sm,
+  },
+  deleteButton: {
+    padding: SPACING.sm,
+    marginLeft: SPACING.sm,
+  },
+  deleteText: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    fontWeight: TYPOGRAPHY.weights.bold,
+  },
+  addButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderWidth: 1,
+    borderRadius: BORDER_RADIUS.md,
+    borderStyle: 'dashed',
+    marginTop: SPACING.sm,
+  },
+  addButtonText: {
+    fontSize: TYPOGRAPHY.sizes.sm,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+  },
+})

--- a/magni/components/workouts/WorkoutCardMetrics.tsx
+++ b/magni/components/workouts/WorkoutCardMetrics.tsx
@@ -31,13 +31,17 @@ export const WorkoutCardMetrics: React.FC<WorkoutCardMetricsProps> = ({ workout 
     )
   }
 
+  const hasMaxPercentage = !!(workout.exerciseMaxId && workout.maxPercentage)
+
   return (
     <View style={styles.metricsRow}>
       <Text style={[styles.metric, { color: colors.text.secondary }]}>
         Sets: <Text style={[styles.metricValue, { color: colors.text.primary }]}>{workout.sets}</Text>
       </Text>
       <Text style={[styles.metric, { color: colors.text.secondary }]}>
-        Weight: <Text style={[styles.metricValue, { color: colors.text.primary }]}>{workout.weight}</Text>
+        Weight: <Text style={[styles.metricValue, { color: colors.text.primary }]}>
+          {workout.weight}{hasMaxPercentage ? ` (${workout.maxPercentage}%)` : ''}
+        </Text>
       </Text>
       <Text style={[styles.metric, { color: colors.text.secondary }]}>
         Reps: <Text style={[styles.metricValue, { color: colors.text.primary }]}>{workout.reps}</Text>

--- a/magni/components/workouts/WorkoutCreateUpdateForm.tsx
+++ b/magni/components/workouts/WorkoutCreateUpdateForm.tsx
@@ -12,7 +12,9 @@ import {
 } from 'react-native'
 import { WorkoutDay } from '../../lib/models/WorkoutDay'
 import { WorkoutValidator, SetDetail } from '../../lib/models/Workout'
+import { ExerciseMax, calculateWorkingWeight } from '../../lib/models/ExerciseMax'
 import { workoutService } from '../../lib/services/WorkoutService'
+import { exerciseMaxService } from '../../lib/services/ExerciseMaxService'
 import { useThemeColors } from '../../hooks/useThemeColors'
 import { confirmAlert } from '../../utils/confirm'
 import { SPACING, TYPOGRAPHY, BORDER_RADIUS } from '../../lib/constants/ui'
@@ -60,8 +62,16 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
     weight?: string;
     sets?: string;
     reps?: string;
+    percentage?: string;
     setDetails?: Record<number, { weight?: string; reps?: string }>;
   }>({})
+
+  const [exerciseMaxes, setExerciseMaxes] = useState<ExerciseMax[]>([])
+  const [useMaxPercentage, setUseMaxPercentage] = useState<boolean>(!!workout?.exerciseMaxId)
+  const [selectedMaxId, setSelectedMaxId] = useState<string>(workout?.exerciseMaxId || '')
+  const [maxPercentage, setMaxPercentage] = useState<string>(workout?.maxPercentage?.toString() || '0')
+  const [showMaxDropdown, setShowMaxDropdown] = useState(false)
+  const [hasHydratedPerSetPercentages, setHasHydratedPerSetPercentages] = useState(false)
 
   useEffect(() => {
     if (workout?.altParentId) {
@@ -74,24 +84,77 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
     } else {
       setSupersetId('')
     }
+    if (workout?.exerciseMaxId) {
+      setUseMaxPercentage(true)
+      setSelectedMaxId(workout.exerciseMaxId)
+      setMaxPercentage(workout.maxPercentage?.toString() || '0')
+    } else {
+      setUseMaxPercentage(false)
+      setSelectedMaxId('')
+      setMaxPercentage('0')
+    }
+    setHasHydratedPerSetPercentages(false)
     setErrors({})
   }, [workout])
+
+  useEffect(() => {
+    const loadMaxes = async () => {
+      const data = await exerciseMaxService.getExerciseMaxes()
+      setExerciseMaxes(data)
+    }
+    loadMaxes()
+  }, [])
+
+  const selectedMax = exerciseMaxes.find(m => m.id === selectedMaxId)
+  const derivedWeight = selectedMax && maxPercentage
+    ? calculateWorkingWeight(selectedMax.maxWeight, Number(maxPercentage))
+    : 0
+
+  const convertWeightToPercentage = (absoluteWeight: number, maxWeight: number): number => {
+    if (maxWeight <= 0) return 0
+    return Math.round((absoluteWeight / maxWeight) * 100)
+  }
+
+  useEffect(() => {
+    if (
+      !hasHydratedPerSetPercentages
+      && workout?.exerciseMaxId
+      && workout?.setDetails
+      && workout.setDetails.length > 0
+      && selectedMax
+      && perSetMode
+      && useMaxPercentage
+    ) {
+      setSetDetails(workout.setDetails.map(detail => ({
+        weight: convertWeightToPercentage(detail.weight, selectedMax.maxWeight),
+        reps: detail.reps,
+      })))
+      setHasHydratedPerSetPercentages(true)
+    }
+  }, [hasHydratedPerSetPercentages, workout, selectedMax, perSetMode, useMaxPercentage])
 
   const validateForm = (): boolean => {
     const newErrors: typeof errors = {}
 
-    if (!name.trim()) {
+    if (!useMaxPercentage && !name.trim()) {
       newErrors.name = 'Name is required'
     }
 
     if (perSetMode) {
+      if (useMaxPercentage && !selectedMaxId) {
+        newErrors.weight = 'Please select an exercise max'
+      }
       if (setDetails.length === 0) {
         newErrors.sets = 'Add at least one set'
       }
       const detailErrors: Record<number, { weight?: string; reps?: string }> = {}
       setDetails.forEach((detail, index) => {
         const rowErrors: { weight?: string; reps?: string } = {}
-        if (isNaN(detail.weight) || detail.weight < 0) {
+        if (useMaxPercentage) {
+          if (isNaN(detail.weight) || detail.weight <= 0 || detail.weight > 200) {
+            rowErrors.weight = 'Invalid %'
+          }
+        } else if (isNaN(detail.weight) || detail.weight < 0) {
           rowErrors.weight = 'Invalid'
         }
         if (isNaN(detail.reps) || detail.reps < 0) {
@@ -103,6 +166,22 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
       })
       if (Object.keys(detailErrors).length > 0) {
         newErrors.setDetails = detailErrors
+      }
+    } else if (useMaxPercentage) {
+      if (!selectedMaxId) {
+        newErrors.weight = 'Please select an exercise max'
+      }
+      const pct = Number(maxPercentage)
+      if (maxPercentage === '' || isNaN(pct) || pct <= 0 || pct > 200) {
+        newErrors.percentage = 'Enter a valid percentage (1-200)'
+      }
+      const setsNum = Number(sets)
+      if (sets === '' || sets.trim() === '' || isNaN(setsNum) || setsNum < 0) {
+        newErrors.sets = 'Please enter a valid number of sets'
+      }
+      const repsNum = Number(reps)
+      if (reps === '' || reps.trim() === '' || isNaN(repsNum) || repsNum < 0) {
+        newErrors.reps = 'Please enter a valid number of reps'
       }
     } else {
       const weightNum = Number(weight)
@@ -128,29 +207,50 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
 
     try {
       const workoutDay = workout?.day ?? day
+      const resolvedSetDetails = perSetMode
+        ? (
+          useMaxPercentage && selectedMax
+            ? setDetails.map(detail => ({
+              weight: calculateWorkingWeight(selectedMax.maxWeight, detail.weight),
+              reps: detail.reps,
+            }))
+            : setDetails
+        )
+        : undefined
 
-      const resolvedWeight = perSetMode && setDetails.length > 0
-        ? setDetails[0].weight
-        : Number(weight)
+      let resolvedWeight: number
+      if (perSetMode && resolvedSetDetails && resolvedSetDetails.length > 0) {
+        resolvedWeight = resolvedSetDetails[0].weight
+      } else if (useMaxPercentage && selectedMax) {
+        resolvedWeight = derivedWeight
+      } else {
+        resolvedWeight = Number(weight)
+      }
       const resolvedSets = perSetMode
-        ? setDetails.length
+        ? (resolvedSetDetails?.length || 0)
         : Number(sets)
-      const resolvedReps = perSetMode && setDetails.length > 0
-        ? setDetails[0].reps
+      const resolvedReps = perSetMode && resolvedSetDetails && resolvedSetDetails.length > 0
+        ? resolvedSetDetails[0].reps
         : Number(reps)
+
+      const resolvedName = useMaxPercentage && selectedMax
+        ? selectedMax.name
+        : name.trim()
 
       const workoutData: WorkoutDay = {
         id: workout?.id || Date.now().toString(),
         day: workoutDay,
         dayOrder: workout?.dayOrder ?? defaultOrder,
-        name: name.trim(),
+        name: resolvedName,
         weight: resolvedWeight,
         sets: resolvedSets,
         reps: resolvedReps,
         notes: notes.trim() || undefined,
         altParentId: alternativeId || undefined,
         supersetParentId: supersetId || undefined,
-        setDetails: perSetMode ? setDetails : undefined,
+        setDetails: resolvedSetDetails,
+        exerciseMaxId: useMaxPercentage ? selectedMaxId || undefined : undefined,
+        maxPercentage: useMaxPercentage && !perSetMode ? Number(maxPercentage) || undefined : undefined,
       }
 
       WorkoutValidator.validate(workoutData)
@@ -391,15 +491,213 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
     )
   }
 
+  const handleToggleMaxPercentage = () => {
+    const turningOn = !useMaxPercentage
+    if (turningOn && !selectedMaxId && exerciseMaxes.length > 0) {
+      setSelectedMaxId(exerciseMaxes[0].id)
+    }
+
+    if (perSetMode) {
+      const maxForConversion = selectedMax || (exerciseMaxes.length > 0 ? exerciseMaxes[0] : undefined)
+      if (turningOn && maxForConversion) {
+        setSetDetails(prev => prev.map(detail => ({
+          weight: convertWeightToPercentage(detail.weight, maxForConversion.maxWeight),
+          reps: detail.reps,
+        })))
+      } else if (!turningOn && selectedMax) {
+        setSetDetails(prev => prev.map(detail => ({
+          weight: calculateWorkingWeight(selectedMax.maxWeight, detail.weight),
+          reps: detail.reps,
+        })))
+      }
+    }
+
+    setUseMaxPercentage(turningOn)
+    setErrors({})
+  }
+
+  const renderMaxPercentageFields = () => {
+    const maxOptions = exerciseMaxes
+    const selectedMaxOption = maxOptions.find(m => m.id === selectedMaxId)
+    const displayText = selectedMaxOption
+      ? `${selectedMaxOption.name} (${selectedMaxOption.maxWeight})`
+      : 'Select Exercise'
+
+    return (
+      <View style={formStyles.maxPercentageContainer}>
+        <View style={styles.inputContainer}>
+          <Text style={[styles.inputLabel, { color: colors.text.primary }]}>Name</Text>
+          <TouchableOpacity
+            style={[styles.dropdownButton, {
+              backgroundColor: colors.surface,
+              borderColor: errors.weight ? '#ff4444' : colors.border,
+            }]}
+            onPress={() => setShowMaxDropdown(true)}
+            accessibilityLabel="Select exercise max"
+            accessibilityRole="button"
+          >
+            <Text style={[styles.dropdownButtonText, { color: colors.text.primary }]}>
+              {displayText}
+            </Text>
+            <Text style={[styles.dropdownArrow, { color: colors.text.secondary }]}>▼</Text>
+          </TouchableOpacity>
+          {errors.weight && (
+            <Text style={[styles.errorText, { color: '#ff4444' }]}>{errors.weight}</Text>
+          )}
+
+          <Modal
+            visible={showMaxDropdown}
+            transparent
+            animationType="fade"
+            onRequestClose={() => setShowMaxDropdown(false)}
+          >
+            <TouchableOpacity
+              style={styles.modalOverlay}
+              activeOpacity={1}
+              onPress={() => setShowMaxDropdown(false)}
+            >
+              <View style={[styles.dropdownModal, { backgroundColor: colors.surface }]}>
+                {maxOptions.map((option, index) => (
+                  <TouchableOpacity
+                    key={option.id}
+                    style={[
+                      styles.dropdownModalOption,
+                      index === maxOptions.length - 1 && styles.dropdownModalOptionLast,
+                    ]}
+                    onPress={() => {
+                      setSelectedMaxId(option.id)
+                      setShowMaxDropdown(false)
+                      if (errors.weight) setErrors(prev => ({ ...prev, weight: undefined }))
+                    }}
+                  >
+                    <Text style={[styles.dropdownModalText, { color: colors.text.primary }]}>
+                      {option.name} ({option.maxWeight})
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </TouchableOpacity>
+          </Modal>
+        </View>
+
+        <View style={styles.row}>
+          <View style={styles.inputContainer}>
+            <Text style={[styles.inputLabel, { color: colors.text.primary }]}>Percentage</Text>
+            <TextInput
+              style={[styles.input, {
+                backgroundColor: colors.surface,
+                color: colors.text.primary,
+                borderColor: errors.percentage ? '#ff4444' : colors.border,
+              }]}
+              value={maxPercentage}
+              onChangeText={(text) => {
+                setMaxPercentage(text)
+                if (errors.percentage) setErrors(prev => ({ ...prev, percentage: undefined }))
+              }}
+              placeholder="0"
+              placeholderTextColor={colors.text.tertiary}
+              keyboardType="numeric"
+              accessibilityLabel="Percentage of max"
+            />
+            {errors.percentage && (
+              <Text style={[styles.errorText, { color: '#ff4444' }]}>{errors.percentage}</Text>
+            )}
+          </View>
+
+          <View style={[styles.inputContainer, { justifyContent: 'center' }]}>
+            <Text style={[styles.inputLabel, { color: colors.text.primary }]}>Weight</Text>
+            <View style={[styles.input, {
+              backgroundColor: colors.surface,
+              borderColor: colors.border,
+              justifyContent: 'center',
+            }]}>
+              <Text style={[formStyles.derivedWeightText, { color: colors.text.primary }]}>
+                {derivedWeight > 0 ? derivedWeight : '—'}
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  const renderMaxSelectorField = () => {
+    const selectedMaxOption = exerciseMaxes.find(m => m.id === selectedMaxId)
+    const displayText = selectedMaxOption
+      ? `${selectedMaxOption.name} (${selectedMaxOption.maxWeight})`
+      : 'Select Exercise'
+
+    return (
+      <View style={styles.inputContainer}>
+        <Text style={[styles.inputLabel, { color: colors.text.primary }]}>Name</Text>
+        <TouchableOpacity
+          style={[styles.dropdownButton, {
+            backgroundColor: colors.surface,
+            borderColor: errors.weight ? '#ff4444' : colors.border,
+          }]}
+          onPress={() => setShowMaxDropdown(true)}
+          accessibilityLabel="Select exercise max"
+          accessibilityRole="button"
+        >
+          <Text style={[styles.dropdownButtonText, { color: colors.text.primary }]}>
+            {displayText}
+          </Text>
+          <Text style={[styles.dropdownArrow, { color: colors.text.secondary }]}>▼</Text>
+        </TouchableOpacity>
+        {errors.weight && (
+          <Text style={[styles.errorText, { color: '#ff4444' }]}>{errors.weight}</Text>
+        )}
+
+        <Modal
+          visible={showMaxDropdown}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setShowMaxDropdown(false)}
+        >
+          <TouchableOpacity
+            style={styles.modalOverlay}
+            activeOpacity={1}
+            onPress={() => setShowMaxDropdown(false)}
+          >
+            <View style={[styles.dropdownModal, { backgroundColor: colors.surface }]}>
+              {exerciseMaxes.map((option, index) => (
+                <TouchableOpacity
+                  key={option.id}
+                  style={[
+                    styles.dropdownModalOption,
+                    index === exerciseMaxes.length - 1 && styles.dropdownModalOptionLast,
+                  ]}
+                  onPress={() => {
+                    setSelectedMaxId(option.id)
+                    setShowMaxDropdown(false)
+                    if (errors.weight) setErrors(prev => ({ ...prev, weight: undefined }))
+                  }}
+                >
+                  <Text style={[styles.dropdownModalText, { color: colors.text.primary }]}>
+                    {option.name} ({option.maxWeight})
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </TouchableOpacity>
+        </Modal>
+      </View>
+    )
+  }
+
   const handleTogglePerSetMode = () => {
     if (!perSetMode) {
       const count = Math.max(Number(sets) || 1, 1)
-      const w = Number(weight) || 0
+      const w = useMaxPercentage ? (Number(maxPercentage) || 0) : (Number(weight) || 0)
       const r = Number(reps) || 0
       setSetDetails(Array.from({ length: count }, () => ({ weight: w, reps: r })))
     } else {
       if (setDetails.length > 0) {
-        setWeight(String(setDetails[0].weight))
+        if (useMaxPercentage) {
+          setMaxPercentage(String(setDetails[0].weight))
+        } else {
+          setWeight(String(setDetails[0].weight))
+        }
         setReps(String(setDetails[0].reps))
         setSets(String(setDetails.length))
       }
@@ -464,8 +762,19 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
             { color: colors.text.secondary },
           ]}
         >
-          Weight
+          {useMaxPercentage ? 'Percentage' : 'Weight'}
         </Text>
+        {useMaxPercentage && (
+          <Text
+            style={[
+              formStyles.setDetailsHeaderText,
+              formStyles.setDetailsValueColumn,
+              { color: colors.text.secondary },
+            ]}
+          >
+            Weight
+          </Text>
+        )}
         <Text
           style={[
             formStyles.setDetailsHeaderText,
@@ -502,6 +811,22 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
             placeholder="0"
             placeholderTextColor={colors.text.tertiary}
           />
+          {useMaxPercentage && (
+            <View
+              style={[
+                formStyles.setDetailInput,
+                {
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                  justifyContent: 'center',
+                },
+              ]}
+            >
+              <Text style={[formStyles.derivedWeightText, { color: colors.text.primary }]}>
+                {selectedMax ? calculateWorkingWeight(selectedMax.maxWeight, detail.weight) : '—'}
+              </Text>
+            </View>
+          )}
           <TextInput
             style={[
               formStyles.setDetailInput,
@@ -545,9 +870,11 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
     >
       <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
         <View style={[styles.form, { backgroundColor: colors.background }]}>
-          {renderInputField('Name', name, setName, 'Exercise name', 'default', false, errors.name, 'name')}
+          {!useMaxPercentage && (
+            renderInputField('Name', name, setName, 'Exercise name', 'default', false, errors.name, 'name')
+          )}
           
-          {!perSetMode && (
+          {!perSetMode && !useMaxPercentage && (
             <View style={styles.row}>
               {renderInputField('Weight', weight, setWeight, '0', 'numeric', false, errors.weight, 'weight')}
               {renderInputField('Sets', sets, setSets, '0', 'numeric', false, errors.sets, 'sets')}
@@ -555,14 +882,43 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
             </View>
           )}
 
-          <TouchableOpacity
-            style={[formStyles.toggleButton, { borderColor: colors.border }]}
-            onPress={handleTogglePerSetMode}
-          >
-            <Text style={[formStyles.toggleButtonText, { color: colors.primary }]}>
-              {perSetMode ? 'Use Standard Mode' : 'Per-Set Details'}
-            </Text>
-          </TouchableOpacity>
+          {!perSetMode && useMaxPercentage && (
+            <View>
+              {renderMaxPercentageFields()}
+              <View style={styles.row}>
+                {renderInputField('Sets', sets, setSets, '0', 'numeric', false, errors.sets, 'sets')}
+                {renderInputField('Reps', reps, setReps, '0', 'numeric', false, errors.reps, 'reps')}
+              </View>
+            </View>
+          )}
+
+          {perSetMode && useMaxPercentage && (
+            <View>
+              {renderMaxSelectorField()}
+            </View>
+          )}
+
+          <View style={formStyles.toggleRow}>
+            <TouchableOpacity
+              style={[formStyles.toggleButton, { borderColor: colors.border }]}
+              onPress={handleTogglePerSetMode}
+            >
+              <Text style={[formStyles.toggleButtonText, { color: colors.primary }]}>
+                {perSetMode ? 'Use Standard Mode' : 'Per-Set Details'}
+              </Text>
+            </TouchableOpacity>
+
+            {exerciseMaxes.length > 0 && (
+              <TouchableOpacity
+                style={[formStyles.toggleButton, { borderColor: colors.border }]}
+                onPress={handleToggleMaxPercentage}
+              >
+                <Text style={[formStyles.toggleButtonText, { color: colors.primary }]}>
+                  {useMaxPercentage ? 'Manual Mode' : '% of Max'}
+                </Text>
+              </TouchableOpacity>
+            )}
+          </View>
 
           {perSetMode && renderPerSetDetails()}
 
@@ -749,14 +1105,18 @@ const styles = StyleSheet.create({
 })
 
 const formStyles = StyleSheet.create({
+  toggleRow: {
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    marginBottom: SPACING.lg,
+    marginHorizontal: 4,
+  },
   toggleButton: {
     alignSelf: 'flex-start',
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.sm,
     borderWidth: 1,
     borderRadius: BORDER_RADIUS.md,
-    marginBottom: SPACING.lg,
-    marginHorizontal: 4,
   },
   toggleButtonText: {
     fontSize: TYPOGRAPHY.sizes.sm,
@@ -842,5 +1202,12 @@ const formStyles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: SPACING.sm,
     width: '100%',
+  },
+  maxPercentageContainer: {
+    marginBottom: SPACING.sm,
+  },
+  derivedWeightText: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    fontWeight: TYPOGRAPHY.weights.semibold,
   },
 })

--- a/magni/jest.setup.js
+++ b/magni/jest.setup.js
@@ -55,7 +55,12 @@ beforeAll(() => {
        args[0].includes('Error adding weight:') ||
        args[0].includes('Error calculating averages:') ||
        args[0].includes('Error getting current day:') ||
-       args[0].includes('Error setting current day:'))
+       args[0].includes('Error setting current day:') ||
+       args[0].includes('Error getting exercise maxes:') ||
+       args[0].includes('Error creating exercise max:') ||
+       args[0].includes('Error updating exercise max:') ||
+       args[0].includes('Error removing exercise max:') ||
+       args[0].includes('Error getting exercise max by id:'))
     ) {
       return;
     }

--- a/magni/lib/models/ExerciseMax.ts
+++ b/magni/lib/models/ExerciseMax.ts
@@ -1,0 +1,53 @@
+export interface ExerciseMax {
+  id: string;
+  name: string;
+  maxWeight: number;
+  lastUpdated: string;
+}
+
+export const ExerciseMaxConverter = {
+  toData: (exerciseMax: ExerciseMax): ExerciseMax => exerciseMax,
+  fromData: (data: ExerciseMax): ExerciseMax => data,
+}
+
+export const EXERCISE_MAX_CONSTRAINTS = {
+  NAME_LENGTH_LIMIT: 100,
+  WEIGHT_LIMIT: 9999,
+  AMRAP_REPS_LIMIT: 100,
+} as const
+
+export class ExerciseMaxValidator {
+  static validate(exerciseMax: ExerciseMax): void {
+    if (!exerciseMax.name || exerciseMax.name.trim().length === 0) {
+      throw new Error('Exercise name is required.')
+    }
+    if (exerciseMax.name.length > EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT) {
+      throw new Error(`Exercise name cannot exceed ${EXERCISE_MAX_CONSTRAINTS.NAME_LENGTH_LIMIT} characters.`)
+    }
+    if (exerciseMax.maxWeight < 0) {
+      throw new Error('Max weight cannot be negative.')
+    }
+    if (exerciseMax.maxWeight > EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT) {
+      throw new Error(`Max weight cannot exceed ${EXERCISE_MAX_CONSTRAINTS.WEIGHT_LIMIT}.`)
+    }
+  }
+}
+
+/**
+ * Epley formula: e1RM = weight × (1 + reps / 30)
+ * Returns 0 if inputs are invalid.
+ */
+export const calculateE1RM = (weight: number, reps: number): number => {
+  if (weight <= 0 || reps <= 0) return 0
+  if (reps === 1) return weight
+  return Math.round(weight * (1 + reps / 30))
+}
+
+/**
+ * Calculate the working weight from a max and a percentage.
+ * Rounds to the nearest whole number.
+ */
+export const calculateWorkingWeight = (maxWeight: number, percentage: number): number => {
+  if (maxWeight <= 0 || percentage <= 0) return 0
+  return Math.round(maxWeight * percentage / 100)
+}

--- a/magni/lib/models/Workout.ts
+++ b/magni/lib/models/Workout.ts
@@ -13,6 +13,8 @@ export interface Workout {
   supersetParentId?: string;
   altParentId?: string;
   setDetails?: SetDetail[];
+  exerciseMaxId?: string;
+  maxPercentage?: number;
 }
 
 export const WorkoutConverter = {

--- a/magni/lib/services/ExerciseMaxService.ts
+++ b/magni/lib/services/ExerciseMaxService.ts
@@ -1,0 +1,85 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { ExerciseMax, ExerciseMaxValidator } from '../models/ExerciseMax'
+
+const EXERCISE_MAX_STORAGE_KEY = 'exercise_maxes'
+
+class ExerciseMaxService {
+  private static instance: ExerciseMaxService
+
+  private constructor() {}
+
+  static getInstance(): ExerciseMaxService {
+    if (!ExerciseMaxService.instance) {
+      ExerciseMaxService.instance = new ExerciseMaxService()
+    }
+    return ExerciseMaxService.instance
+  }
+
+  async getExerciseMaxes(): Promise<ExerciseMax[]> {
+    try {
+      const json = await AsyncStorage.getItem(EXERCISE_MAX_STORAGE_KEY)
+      if (!json) return []
+      return JSON.parse(json) as ExerciseMax[]
+    } catch (error) {
+      console.error('Error getting exercise maxes:', error)
+      return []
+    }
+  }
+
+  async getExerciseMaxById(id: string): Promise<ExerciseMax | undefined> {
+    try {
+      const maxes = await this.getExerciseMaxes()
+      return maxes.find(m => m.id === id)
+    } catch (error) {
+      console.error('Error getting exercise max by id:', error)
+      return undefined
+    }
+  }
+
+  async createExerciseMax(exerciseMax: ExerciseMax): Promise<boolean> {
+    try {
+      ExerciseMaxValidator.validate(exerciseMax)
+
+      const existing = await this.getExerciseMaxes()
+      const updated = [exerciseMax, ...existing]
+
+      await AsyncStorage.setItem(EXERCISE_MAX_STORAGE_KEY, JSON.stringify(updated))
+      return true
+    } catch (error) {
+      console.error('Error creating exercise max:', error)
+      return false
+    }
+  }
+
+  async updateExerciseMax(exerciseMax: ExerciseMax): Promise<boolean> {
+    try {
+      ExerciseMaxValidator.validate(exerciseMax)
+
+      const existing = await this.getExerciseMaxes()
+      const updated = existing.map(m =>
+        m.id === exerciseMax.id ? exerciseMax : m,
+      )
+
+      await AsyncStorage.setItem(EXERCISE_MAX_STORAGE_KEY, JSON.stringify(updated))
+      return true
+    } catch (error) {
+      console.error('Error updating exercise max:', error)
+      return false
+    }
+  }
+
+  async removeExerciseMax(id: string): Promise<boolean> {
+    try {
+      const existing = await this.getExerciseMaxes()
+      const filtered = existing.filter(m => m.id !== id)
+
+      await AsyncStorage.setItem(EXERCISE_MAX_STORAGE_KEY, JSON.stringify(filtered))
+      return true
+    } catch (error) {
+      console.error('Error removing exercise max:', error)
+      return false
+    }
+  }
+}
+
+export const exerciseMaxService = ExerciseMaxService.getInstance()


### PR DESCRIPTION
- Adds Exercise Max management under Settings, including create/edit/delete and AMRAP-based estimated 1RM (e1RM = weight * (1 + reps / 30)).
- Adds % of Max programming in workout creation, including support for both standard and per-set details modes.
In % of Max mode, workout name is derived from the selected max, and workout cards display percentage-based weight context.
- Persists new max metadata on workouts (exerciseMaxId, maxPercentage) and introduces model/service coverage for exercise max storage and calculations.
