### PR TITLE
feat: Add Existing Workout

### DIFF
--- a/magni/__tests__/components/workouts/WorkoutCreateUpdateForm.day.test.ts
+++ b/magni/__tests__/components/workouts/WorkoutCreateUpdateForm.day.test.ts
@@ -229,5 +229,63 @@ describe('WorkoutCreateUpdateForm Day Preservation Logic', () => {
       expect(updatedWorkout.supersetParentId).toBe(originalWorkout.supersetParentId)
     })
   })
+
+  describe('Create from existing workout linking', () => {
+    it('should link new workout to the selected existing workout group', async () => {
+      const existingWorkout: WorkoutDay = createMockWorkoutDay({
+        id: 'existing-workout',
+        name: 'Romanian Deadlift',
+        day: 1,
+      })
+
+      // Simulate "Create from Existing" behavior in the form.
+      const sharedWorkoutId = existingWorkout.sharedWorkoutId ?? existingWorkout.id
+      const newWorkout: WorkoutDay = createMockWorkoutDay({
+        id: 'copied-workout',
+        day: 3,
+        dayOrder: 0,
+        name: existingWorkout.name,
+        weight: existingWorkout.weight,
+        sets: existingWorkout.sets,
+        reps: existingWorkout.reps,
+        sharedWorkoutId,
+      })
+
+      await mockWorkoutService.createWorkout(newWorkout)
+
+      expect(newWorkout.sharedWorkoutId).toBe('existing-workout')
+      expect(newWorkout.day).toBe(3)
+      expect(mockWorkoutService.createWorkout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'copied-workout',
+          sharedWorkoutId: 'existing-workout',
+        }),
+      )
+    })
+
+    it('should keep linking to the original source when copying an already linked workout', async () => {
+      const linkedWorkout: WorkoutDay = createMockWorkoutDay({
+        id: 'linked-workout',
+        sharedWorkoutId: 'master-workout',
+        name: 'Incline Bench',
+      })
+
+      const sharedWorkoutId = linkedWorkout.sharedWorkoutId ?? linkedWorkout.id
+      const newWorkout: WorkoutDay = createMockWorkoutDay({
+        id: 'another-copy',
+        sharedWorkoutId,
+        day: 2,
+      })
+
+      await mockWorkoutService.createWorkout(newWorkout)
+
+      expect(newWorkout.sharedWorkoutId).toBe('master-workout')
+      expect(mockWorkoutService.createWorkout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sharedWorkoutId: 'master-workout',
+        }),
+      )
+    })
+  })
 })
 

--- a/magni/__tests__/lib/services/WorkoutService.test.ts
+++ b/magni/__tests__/lib/services/WorkoutService.test.ts
@@ -40,7 +40,7 @@ afterAll(() => {
 
 describe('WorkoutService', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
   })
 
   describe('getWorkouts', () => {
@@ -303,7 +303,7 @@ describe('WorkoutService', () => {
 
       await workoutService.createWorkout(newWorkout)
 
-      const setItemCall = mockSetItem.mock.calls[0]
+      const setItemCall = mockSetItem.mock.calls[mockSetItem.mock.calls.length - 1]
       const storedData = JSON.parse(setItemCall[1] as string)
 
       expect(storedData).toHaveLength(2)
@@ -360,7 +360,7 @@ describe('WorkoutService', () => {
 
       expect(result).toBe(true)
 
-      const setItemCall = mockSetItem.mock.calls[0]
+      const setItemCall = mockSetItem.mock.calls[mockSetItem.mock.calls.length - 1]
       const storedData = JSON.parse(setItemCall[1] as string)
 
       expect(storedData).toHaveLength(2)
@@ -379,7 +379,7 @@ describe('WorkoutService', () => {
 
       expect(result).toBe(true)
 
-      const setItemCall = mockSetItem.mock.calls[0]
+      const setItemCall = mockSetItem.mock.calls[mockSetItem.mock.calls.length - 1]
       const storedData = JSON.parse(setItemCall[1] as string)
 
       expect(storedData).toHaveLength(1) // Should still have the existing workout
@@ -427,7 +427,7 @@ describe('WorkoutService', () => {
 
       expect(result).toBe(true)
 
-      const setItemCall = mockSetItem.mock.calls[0]
+      const setItemCall = mockSetItem.mock.calls[mockSetItem.mock.calls.length - 1]
       const storedData = JSON.parse(setItemCall[1] as string)
 
       const updatedItem = storedData.find((w: any) => w.id === 'update-1')
@@ -476,6 +476,126 @@ describe('WorkoutService', () => {
       const result = await workoutService.updateWorkout(updatedWorkout)
 
       expect(result).toBe(false)
+    })
+
+    it('updates all workouts linked by sharedWorkoutId', async () => {
+      const existingWorkouts = [
+        createMockWorkoutDay({
+          id: 'master-workout',
+          name: 'Bench Press',
+          weight: 100,
+          day: 1,
+        }),
+        createMockWorkoutDay({
+          id: 'linked-workout',
+          sharedWorkoutId: 'master-workout',
+          name: 'Bench Press',
+          weight: 100,
+          day: 2,
+          dayOrder: 3,
+          altParentId: 'alt-relationship',
+        }),
+        createMockWorkoutDay({
+          id: 'unrelated-workout',
+          name: 'Squat',
+          weight: 200,
+          day: 1,
+        }),
+      ]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(existingWorkouts))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const updatedWorkout = createMockWorkoutDay({
+        id: 'master-workout',
+        name: 'Paused Bench Press',
+        weight: 115,
+        sets: 5,
+        reps: 5,
+        notes: 'Use spotter',
+      })
+
+      const result = await workoutService.updateWorkout(updatedWorkout)
+
+      expect(result).toBe(true)
+
+      const setItemCall = mockSetItem.mock.calls[0]
+      const storedData = JSON.parse(setItemCall[1] as string)
+      const storedIds = storedData.map((w: any) => w.id)
+
+      expect(storedIds).toEqual(expect.arrayContaining([
+        'master-workout',
+        'linked-workout',
+        'unrelated-workout',
+      ]))
+
+      const updatedMaster = storedData.find((w: any) => w.id === 'master-workout')
+      const updatedLinked = storedData.find((w: any) => w.id === 'linked-workout')
+      const untouchedWorkout = storedData.find((w: any) => w.id === 'unrelated-workout')
+
+      expect(updatedMaster.name).toBe('Paused Bench Press')
+      expect(updatedLinked.name).toBe('Paused Bench Press')
+      expect(updatedLinked.weight).toBe(115)
+      expect(updatedLinked.sets).toBe(5)
+      expect(updatedLinked.reps).toBe(5)
+      expect(updatedLinked.notes).toBe('Use spotter')
+
+      // Day and relationship metadata should stay local to each workout instance.
+      expect(updatedLinked.day).toBe(2)
+      expect(updatedLinked.dayOrder).toBe(3)
+      expect(updatedLinked.altParentId).toBe('alt-relationship')
+
+      expect(untouchedWorkout.name).toBe('Squat')
+      expect(untouchedWorkout.weight).toBe(200)
+    })
+
+    it('updates master workout when editing a linked workout', async () => {
+      const existingWorkouts = [
+        createMockWorkoutDay({
+          id: 'master-workout',
+          name: 'Overhead Press',
+          weight: 60,
+          sets: 3,
+          reps: 8,
+        }),
+        createMockWorkoutDay({
+          id: 'linked-workout',
+          sharedWorkoutId: 'master-workout',
+          name: 'Overhead Press',
+          weight: 60,
+          sets: 3,
+          reps: 8,
+          day: 2,
+        }),
+      ]
+
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(existingWorkouts))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const updatedLinkedWorkout = createMockWorkoutDay({
+        id: 'linked-workout',
+        sharedWorkoutId: 'master-workout',
+        name: 'Strict Press',
+        weight: 65,
+        sets: 4,
+        reps: 6,
+        day: 2,
+      })
+
+      const result = await workoutService.updateWorkout(updatedLinkedWorkout)
+
+      expect(result).toBe(true)
+
+      const setItemCall = mockSetItem.mock.calls[0]
+      const storedData = JSON.parse(setItemCall[1] as string)
+      const updatedMaster = storedData.find((w: any) => w.id === 'master-workout')
+      const updatedLinked = storedData.find((w: any) => w.id === 'linked-workout')
+
+      expect(updatedMaster.name).toBe('Strict Press')
+      expect(updatedMaster.weight).toBe(65)
+      expect(updatedMaster.sets).toBe(4)
+      expect(updatedMaster.reps).toBe(6)
+      expect(updatedLinked.day).toBe(2)
     })
   })
 

--- a/magni/components/workouts/WorkoutCreateUpdateForm.tsx
+++ b/magni/components/workouts/WorkoutCreateUpdateForm.tsx
@@ -74,6 +74,14 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
   const [hasHydratedPerSetPercentages, setHasHydratedPerSetPercentages] = useState(false)
 
   useEffect(() => {
+    setName(workout?.name || '')
+    setWeight(workout?.weight?.toString() || '')
+    setSets(workout?.sets?.toString() || '')
+    setReps(workout?.reps?.toString() || '')
+    setNotes(workout?.notes || '')
+    setPerSetMode(!!(workout?.setDetails && workout.setDetails.length > 0))
+    setSetDetails(workout?.setDetails ?? [])
+
     if (workout?.altParentId) {
       setAlternativeId(workout.altParentId)
     } else {
@@ -239,6 +247,7 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
 
       const workoutData: WorkoutDay = {
         id: workout?.id || Date.now().toString(),
+        sharedWorkoutId: workout?.sharedWorkoutId,
         day: workoutDay,
         dayOrder: workout?.dayOrder ?? defaultOrder,
         name: resolvedName,

--- a/magni/components/workouts/WorkoutsConfigure.tsx
+++ b/magni/components/workouts/WorkoutsConfigure.tsx
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
 } from 'react-native'
 import { WorkoutDay } from '../../lib/models/WorkoutDay'
+import { getSyncGroupId } from '../../lib/models/Workout'
 import { workoutService } from '../../lib/services/WorkoutService'
 import { WorkoutCreateUpdateForm } from './WorkoutCreateUpdateForm'
 import { useThemeColors } from '../../hooks/useThemeColors'
@@ -23,6 +24,7 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
   const [isLoading, setIsLoading] = useState(true)
   const [editingWorkout, setEditingWorkout] = useState<WorkoutDay | undefined>()
   const [showForm, setShowForm] = useState(false)
+  const [showExistingWorkoutSelector, setShowExistingWorkoutSelector] = useState(false)
   const [selectedDay, setSelectedDay] = useState(1)
   const [totalDays, setTotalDays] = useState(0)
 
@@ -51,6 +53,10 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
   const handleAddWorkout = () => {
     setEditingWorkout(undefined)
     setShowForm(true)
+  }
+
+  const handleAddExistingWorkout = () => {
+    setShowExistingWorkoutSelector(true)
   }
 
   const handleEditWorkout = (workout: WorkoutDay) => {
@@ -172,7 +178,49 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
     return workouts.filter(w => w.day === day).sort((a, b) => a.dayOrder - b.dayOrder)
   }
 
+  const getSelectableExistingWorkouts = (): WorkoutDay[] => {
+    return workouts
+      .filter((workout, index, allWorkouts) => {
+        const syncKey = getSyncGroupId(workout)
+        return allWorkouts.findIndex(item => getSyncGroupId(item) === syncKey) === index
+      })
+      .sort((first, second) => first.name.localeCompare(second.name))
+  }
 
+  const handleSelectExistingWorkout = async (selectedWorkout: WorkoutDay) => {
+    try {
+      const dayWorkouts = getWorkoutsForDay(selectedDay)
+      const syncGroupId = getSyncGroupId(selectedWorkout)
+      const copiedSetDetails = selectedWorkout.setDetails?.map(detail => ({ ...detail }))
+
+      const newWorkout: WorkoutDay = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        sharedWorkoutId: syncGroupId,
+        day: selectedDay,
+        dayOrder: dayWorkouts.length + 1,
+        name: selectedWorkout.name,
+        weight: selectedWorkout.weight,
+        sets: selectedWorkout.sets,
+        reps: selectedWorkout.reps,
+        notes: selectedWorkout.notes,
+        setDetails: copiedSetDetails,
+        exerciseMaxId: selectedWorkout.exerciseMaxId,
+        maxPercentage: selectedWorkout.maxPercentage,
+      }
+
+      const success = await workoutService.createWorkout(newWorkout)
+      if (!success) {
+        confirmAlert('Error', 'Failed to add existing workout')
+        return
+      }
+
+      setShowExistingWorkoutSelector(false)
+      await loadWorkouts()
+    } catch (error) {
+      console.error('Error selecting existing workout:', error)
+      confirmAlert('Error', 'Failed to add existing workout')
+    }
+  }
 
   const handleNextDay = () => {
     const nextDay = selectedDay + 1
@@ -278,6 +326,39 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
     </View>
   )
 
+  const renderAddButtons = () => (
+    <View style={styles.addButtonsRow}>
+      <TouchableOpacity
+        style={[
+          styles.addButton,
+          styles.addButtonHalf,
+          { backgroundColor: colors.primary },
+        ]}
+        onPress={handleAddWorkout}
+        accessibilityLabel="Add new workout"
+        accessibilityRole="button"
+      >
+        <Text style={[styles.addButtonText, { color: '#fff' }]}>Add New Workout</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[
+          styles.addButton,
+          styles.addButtonHalf,
+          {
+            backgroundColor: colors.surface,
+            borderColor: colors.border,
+            borderWidth: 1,
+          },
+        ]}
+        onPress={handleAddExistingWorkout}
+        accessibilityLabel="Select existing workout"
+        accessibilityRole="button"
+      >
+        <Text style={[styles.addButtonText, { color: colors.text.primary }]}>Select Existing Workout</Text>
+      </TouchableOpacity>
+    </View>
+  )
+
   const renderWorkoutList = () => {
     const dayWorkouts = getWorkoutsForDay(selectedDay)
     
@@ -289,19 +370,8 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
             {isNewDay ? `Create workouts for Day ${selectedDay}` : `No workouts for Day ${selectedDay}`}
           </Text>
           <View style={styles.emptyStateButtons}>
-            <TouchableOpacity 
-              style={[
-                styles.addButton, 
-                { 
-                  backgroundColor: colors.primary,
-                },
-              ]} 
-              onPress={handleAddWorkout}
-            >
-              <Text style={[styles.addButtonText, { color: '#fff' }]}>+ Add Workout</Text>
-            </TouchableOpacity>
+            {renderAddButtons()}
             {!isNewDay && (() => {
-              // Check if this is the last day
               const uniqueDays = Array.from(new Set(workouts.map(w => w.day))).sort((a, b) => a - b)
               const isLastDay = uniqueDays.length > 0 && selectedDay === uniqueDays[uniqueDays.length - 1]
               
@@ -343,18 +413,7 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
             renderWorkoutItem(workout, index, dayWorkouts.length),
           )}
         </ScrollView>
-        
-        <TouchableOpacity 
-          style={[
-            styles.addButton, 
-            { 
-              backgroundColor: colors.primary,
-            },
-          ]} 
-          onPress={handleAddWorkout}
-        >
-          <Text style={[styles.addButtonText, { color: '#fff' }]}>+ Add Workout</Text>
-        </TouchableOpacity>
+        {renderAddButtons()}
       </View>
     )
   }
@@ -389,6 +448,55 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
     </View>
   )
 
+  const renderExistingWorkoutSelectorModal = () => {
+    const selectableWorkouts = getSelectableExistingWorkouts()
+
+    return (
+      <View style={styles.modalOverlay}>
+        <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
+          <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
+            <Text style={[styles.modalTitle, { color: colors.text.primary }]}>
+              Select Existing Workout
+            </Text>
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={() => setShowExistingWorkoutSelector(false)}
+              accessibilityLabel="Close workout selector"
+              accessibilityRole="button"
+            >
+              <Text style={[styles.closeButtonText, { color: colors.text.secondary }]}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView style={styles.existingWorkoutList}>
+            {selectableWorkouts.length === 0 ? (
+              <Text style={[styles.emptyStateText, { color: colors.text.secondary }]}>
+                No existing workouts available
+              </Text>
+            ) : (
+              selectableWorkouts.map(workout => (
+                <TouchableOpacity
+                  key={getSyncGroupId(workout)}
+                  style={[styles.existingWorkoutItem, { backgroundColor: colors.background, borderColor: colors.border }]}
+                  onPress={() => handleSelectExistingWorkout(workout)}
+                  accessibilityLabel={`Select ${workout.name}`}
+                  accessibilityRole="button"
+                >
+                  <Text style={[styles.existingWorkoutName, { color: colors.text.primary }]}>
+                    {workout.name}
+                  </Text>
+                  <Text style={[styles.existingWorkoutDetails, { color: colors.text.secondary }]}>
+                    {workout.weight} lb • {workout.sets} sets • {workout.reps} reps
+                  </Text>
+                </TouchableOpacity>
+              ))
+            )}
+          </ScrollView>
+        </View>
+      </View>
+    )
+  }
+
   if (isLoading) {
     return (
       <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
@@ -414,6 +522,7 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
       </ScrollView>
 
       {showForm && renderFormModal()}
+      {showExistingWorkoutSelector && renderExistingWorkoutSelectorModal()}
     </View>
   )
 }
@@ -619,13 +728,27 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     borderRadius: 8,
     alignItems: 'center',
+    justifyContent: 'center',
     marginTop: 20,
     marginBottom: 20, // Add extra bottom margin
+  },
+  addButtonsRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 20,
+    marginBottom: 20,
+  },
+  addButtonHalf: {
+    flex: 1,
+    marginTop: 0,
+    marginBottom: 0,
+    paddingHorizontal: 12,
   },
   addButtonText: {
     color: '#fff',
     fontSize: 16,
     fontWeight: 'bold',
+    textAlign: 'center',
   },
   deleteDayButton: {
     backgroundColor: '#ff3b30',
@@ -656,6 +779,25 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     width: '100%',
     maxHeight: '80%',
+  },
+  existingWorkoutList: {
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  existingWorkoutItem: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    marginBottom: 10,
+  },
+  existingWorkoutName: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  existingWorkoutDetails: {
+    fontSize: 14,
   },
   modalHeader: {
     flexDirection: 'row',

--- a/magni/lib/models/Workout.ts
+++ b/magni/lib/models/Workout.ts
@@ -5,6 +5,7 @@ export interface SetDetail {
 
 export interface Workout {
   id: string;
+  sharedWorkoutId?: string;
   name: string;
   weight: number;
   sets: number;
@@ -29,6 +30,10 @@ export const WORKOUT_CONSTRAINTS = {
   SETS_LIMIT: 9999,
   REPS_LIMIT: 9999,
 } as const
+
+export function getSyncGroupId(workout: Workout): string {
+  return workout.sharedWorkoutId ?? workout.id
+}
 
 export class WorkoutValidator {
   static validate(workout: Workout): void {

--- a/magni/lib/services/WorkoutService.ts
+++ b/magni/lib/services/WorkoutService.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
 import { WorkoutDay, WorkoutDayValidator } from '../models/WorkoutDay'
-import { WorkoutValidator } from '../models/Workout'
+import { WorkoutValidator, getSyncGroupId } from '../models/Workout'
 
 const WORKOUT_STORAGE_KEY = 'workouts'
 const CURRENT_DAY_STORAGE_KEY = 'current_workout_day'
@@ -10,6 +10,10 @@ class WorkoutService {
   private static instance: WorkoutService
 
   private constructor() {}
+
+  private isWorkoutInSyncGroup(workout: WorkoutDay, syncGroupId: string): boolean {
+    return workout.id === syncGroupId || workout.sharedWorkoutId === syncGroupId
+  }
 
   static getInstance(): WorkoutService {
     if (!WorkoutService.instance) {
@@ -82,9 +86,32 @@ class WorkoutService {
       WorkoutValidator.validate(workout)
       
       const existingWorkouts = await this.getWorkouts()
-      const updatedWorkouts = existingWorkouts.map(w => 
-        w.id === workout.id ? workout : w,
-      )
+      const syncGroupId = getSyncGroupId(workout)
+      const sharedUpdate = {
+        name: workout.name,
+        weight: workout.weight,
+        sets: workout.sets,
+        reps: workout.reps,
+        notes: workout.notes,
+        setDetails: workout.setDetails,
+        exerciseMaxId: workout.exerciseMaxId,
+        maxPercentage: workout.maxPercentage,
+      }
+
+      const updatedWorkouts = existingWorkouts.map(existingWorkout => {
+        if (!this.isWorkoutInSyncGroup(existingWorkout, syncGroupId)) {
+          return existingWorkout
+        }
+
+        if (existingWorkout.id === workout.id) {
+          return workout
+        }
+
+        return {
+          ...existingWorkout,
+          ...sharedUpdate,
+        }
+      })
       
       await AsyncStorage.setItem(WORKOUT_STORAGE_KEY, JSON.stringify(updatedWorkouts))
       return true


### PR DESCRIPTION
- Add a workout from an existing one — On Configure Workouts, use Select Existing Workout to pick from your library. The new entry is added to the current day without opening the create form.
- Synced updates — Exercises that share the same source stay in sync: changing name, weight, sets, reps, notes, per-set details, or max settings on one updates all linked copies. Day, order, and alternative/superset links stay per-day.
- Clearer actions — The primary action is labeled Add New Workout; Select Existing Workout sits beside it for the copy-from-library flow.