### PR TITLE
fix: Percentage of max workouts

### DIFF
--- a/magni/__tests__/lib/models/ExerciseMax.test.ts
+++ b/magni/__tests__/lib/models/ExerciseMax.test.ts
@@ -3,6 +3,7 @@ import {
   ExerciseMaxConverter,
   ExerciseMaxValidator,
   EXERCISE_MAX_CONSTRAINTS,
+  absoluteWeightToMaxPercent,
   calculateE1RM,
   calculateWorkingWeight,
 } from '../../../lib/models/ExerciseMax'
@@ -234,6 +235,17 @@ describe('ExerciseMax Model', () => {
     it('rounds to nearest whole number', () => {
       // 100 * (1 + 7/30) = 100 * 1.2333... = 123.33... → 123
       expect(calculateE1RM(100, 7)).toBe(123)
+    })
+  })
+
+  describe('absoluteWeightToMaxPercent', () => {
+    it('converts absolute weight to rounded percent of max', () => {
+      expect(absoluteWeightToMaxPercent(200, 400)).toBe(50)
+    })
+
+    it('returns 0 when max is zero or negative', () => {
+      expect(absoluteWeightToMaxPercent(200, 0)).toBe(0)
+      expect(absoluteWeightToMaxPercent(200, -100)).toBe(0)
     })
   })
 

--- a/magni/__tests__/lib/services/WorkoutService.test.ts
+++ b/magni/__tests__/lib/services/WorkoutService.test.ts
@@ -790,6 +790,82 @@ describe('WorkoutService', () => {
     })
   })
 
+  describe('applyExerciseMaxChangeToWorkouts', () => {
+    it('updates standard % workouts: same maxPercentage, new weight', async () => {
+      const maxId = 'bench-1'
+      const workouts = [
+        createMockWorkoutDay({
+          id: 'w1',
+          exerciseMaxId: maxId,
+          maxPercentage: 50,
+          weight: 200,
+          day: 1,
+          dayOrder: 0,
+        }),
+        createMockWorkoutDay({
+          id: 'w2',
+          name: 'Other',
+          exerciseMaxId: 'other-max',
+          maxPercentage: 50,
+          weight: 100,
+          day: 1,
+          dayOrder: 1,
+        }),
+      ]
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(workouts))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const ok = await workoutService.applyExerciseMaxChangeToWorkouts(maxId, 500, 400)
+      expect(ok).toBe(true)
+
+      const stored = JSON.parse(mockSetItem.mock.calls[0][1] as string) as WorkoutDay[]
+      expect(stored.find(w => w.id === 'w1')).toMatchObject({
+        maxPercentage: 50,
+        weight: 250,
+      })
+      expect(stored.find(w => w.id === 'w2')).toMatchObject({ weight: 100 })
+    })
+
+    it('updates per-set absolute weights from implied % at previous max', async () => {
+      const maxId = 'squat-1'
+      const workouts = [
+        createMockWorkoutDay({
+          id: 'w1',
+          exerciseMaxId: maxId,
+          sets: 2,
+          reps: 5,
+          weight: 200,
+          setDetails: [
+            { weight: 200, reps: 5 },
+            { weight: 180, reps: 5 },
+          ],
+          day: 1,
+          dayOrder: 0,
+        }),
+      ]
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(workouts))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      await workoutService.applyExerciseMaxChangeToWorkouts(maxId, 500, 400)
+
+      const stored = JSON.parse(mockSetItem.mock.calls[0][1] as string) as WorkoutDay[]
+      const w = stored[0]
+      expect(w.setDetails).toEqual([
+        { weight: 250, reps: 5 },
+        { weight: 225, reps: 5 },
+      ])
+      expect(w.weight).toBe(250)
+    })
+
+    it('no-ops when previous and new max are equal', async () => {
+      mockGetItem.mockResolvedValueOnce(JSON.stringify([createMockWorkoutDay({ exerciseMaxId: 'm1', maxPercentage: 50, weight: 200 })]))
+
+      const ok = await workoutService.applyExerciseMaxChangeToWorkouts('m1', 400, 400)
+      expect(ok).toBe(true)
+      expect(mockSetItem).not.toHaveBeenCalled()
+    })
+  })
+
   describe('Singleton Pattern', () => {
     it('returns the same instance on multiple calls', () => {
       const instance1 = workoutService

--- a/magni/components/settings/ExerciseMaxFormModal.tsx
+++ b/magni/components/settings/ExerciseMaxFormModal.tsx
@@ -12,7 +12,9 @@ import {
 } from 'react-native'
 import { ExerciseMax, calculateE1RM, EXERCISE_MAX_CONSTRAINTS } from '../../lib/models/ExerciseMax'
 import { exerciseMaxService } from '../../lib/services/ExerciseMaxService'
+import { workoutService } from '../../lib/services/WorkoutService'
 import { useThemeColors } from '../../hooks/useThemeColors'
+import { confirmAlert } from '../../utils/confirm'
 import { SPACING, TYPOGRAPHY, BORDER_RADIUS } from '../../lib/constants/ui'
 
 interface ExerciseMaxFormModalProps {
@@ -113,6 +115,20 @@ export default function ExerciseMaxFormModal({
     const success = exerciseMax
       ? await exerciseMaxService.updateExerciseMax(data)
       : await exerciseMaxService.createExerciseMax(data)
+
+    if (success && exerciseMax && exerciseMax.maxWeight !== data.maxWeight) {
+      const synced = await workoutService.applyExerciseMaxChangeToWorkouts(
+        data.id,
+        data.maxWeight,
+        exerciseMax.maxWeight,
+      )
+      if (!synced) {
+        confirmAlert(
+          'Workout update failed',
+          'Your max was saved, but some workouts could not be updated to match. Try editing those workouts manually.',
+        )
+      }
+    }
 
     if (success) {
       onSave(data)

--- a/magni/components/workouts/WorkoutCreateUpdateForm.tsx
+++ b/magni/components/workouts/WorkoutCreateUpdateForm.tsx
@@ -13,7 +13,7 @@ import {
 import { WorkoutDay } from '../../lib/models/WorkoutDay'
 import { WorkoutValidator, SetDetail } from '../../lib/models/Workout'
 import { parseDetailNumberFromInput, setDetailsToPerSetTexts, type PerSetTextRow } from '../../lib/utils/setDetailInput'
-import { ExerciseMax, calculateWorkingWeight } from '../../lib/models/ExerciseMax'
+import { ExerciseMax, absoluteWeightToMaxPercent, calculateWorkingWeight } from '../../lib/models/ExerciseMax'
 import { workoutService } from '../../lib/services/WorkoutService'
 import { exerciseMaxService } from '../../lib/services/ExerciseMaxService'
 import { useThemeColors } from '../../hooks/useThemeColors'
@@ -124,11 +124,6 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
     ? calculateWorkingWeight(selectedMax.maxWeight, Number(maxPercentage))
     : 0
 
-  const convertWeightToPercentage = (absoluteWeight: number, maxWeight: number): number => {
-    if (maxWeight <= 0) return 0
-    return Math.round((absoluteWeight / maxWeight) * 100)
-  }
-
   useEffect(() => {
     if (
       !hasHydratedPerSetPercentages
@@ -140,7 +135,7 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
       && useMaxPercentage
     ) {
       const hydrated = workout.setDetails.map(detail => ({
-        weight: convertWeightToPercentage(detail.weight, selectedMax.maxWeight),
+        weight: absoluteWeightToMaxPercent(detail.weight, selectedMax.maxWeight),
         reps: detail.reps,
       }))
       setSetDetails(hydrated)
@@ -535,7 +530,7 @@ export const WorkoutCreateUpdateForm: React.FC<WorkoutCreateUpdateFormProps> = (
       if (turningOn && maxForConversion) {
         setSetDetails(prev => {
           const next = prev.map(detail => ({
-            weight: convertWeightToPercentage(detail.weight, maxForConversion.maxWeight),
+            weight: absoluteWeightToMaxPercent(detail.weight, maxForConversion.maxWeight),
             reps: detail.reps,
           }))
           setPerSetTexts(setDetailsToPerSetTexts(next))

--- a/magni/lib/models/ExerciseMax.ts
+++ b/magni/lib/models/ExerciseMax.ts
@@ -44,6 +44,14 @@ export const calculateE1RM = (weight: number, reps: number): number => {
 }
 
 /**
+ * Percentage of max implied by an absolute working weight (rounded to whole %).
+ */
+export const absoluteWeightToMaxPercent = (absoluteWeight: number, maxWeight: number): number => {
+  if (maxWeight <= 0) return 0
+  return Math.round((absoluteWeight / maxWeight) * 100)
+}
+
+/**
  * Calculate the working weight from a max and a percentage.
  * Rounds to the nearest whole number.
  */

--- a/magni/lib/services/WorkoutService.ts
+++ b/magni/lib/services/WorkoutService.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
 import { WorkoutDay, WorkoutDayValidator } from '../models/WorkoutDay'
 import { WorkoutValidator, getSyncGroupId } from '../models/Workout'
+import { absoluteWeightToMaxPercent, calculateWorkingWeight } from '../models/ExerciseMax'
 
 const WORKOUT_STORAGE_KEY = 'workouts'
 const CURRENT_DAY_STORAGE_KEY = 'current_workout_day'
@@ -77,6 +78,83 @@ class WorkoutService {
       return true
     } catch (error) {
       console.error('Error removing workout:', error)
+      return false
+    }
+  }
+
+  /**
+   * When a 1RM changes, keep programmed % the same and refresh stored absolute weights.
+   * `previousMaxWeight` is the max before the edit (used to recover % for per-set and legacy rows).
+   */
+  async applyExerciseMaxChangeToWorkouts(
+    exerciseMaxId: string,
+    newMaxWeight: number,
+    previousMaxWeight: number,
+  ): Promise<boolean> {
+    try {
+      if (previousMaxWeight <= 0 || newMaxWeight <= 0 || previousMaxWeight === newMaxWeight) {
+        return true
+      }
+
+      const existingWorkouts = await this.getWorkouts()
+      let anyChanged = false
+
+      const updatedWorkouts = existingWorkouts.map(workout => {
+        if (workout.exerciseMaxId !== exerciseMaxId) {
+          return workout
+        }
+
+        if (WorkoutValidator.hasSetDetails(workout) && workout.setDetails?.length) {
+          const setDetails = workout.setDetails.map(detail => ({
+            reps: detail.reps,
+            weight: calculateWorkingWeight(
+              newMaxWeight,
+              absoluteWeightToMaxPercent(detail.weight, previousMaxWeight),
+            ),
+          }))
+          anyChanged = true
+          const next: WorkoutDay = {
+            ...workout,
+            setDetails,
+            weight: setDetails[0]?.weight ?? workout.weight,
+          }
+          WorkoutValidator.validate(next)
+          return next
+        }
+
+        if (typeof workout.maxPercentage === 'number' && workout.maxPercentage > 0) {
+          const next: WorkoutDay = {
+            ...workout,
+            weight: calculateWorkingWeight(newMaxWeight, workout.maxPercentage),
+          }
+          anyChanged = true
+          WorkoutValidator.validate(next)
+          return next
+        }
+
+        const pct = absoluteWeightToMaxPercent(workout.weight, previousMaxWeight)
+        if (pct <= 0) {
+          return workout
+        }
+
+        const next: WorkoutDay = {
+          ...workout,
+          weight: calculateWorkingWeight(newMaxWeight, pct),
+          maxPercentage: pct,
+        }
+        anyChanged = true
+        WorkoutValidator.validate(next)
+        return next
+      })
+
+      if (!anyChanged) {
+        return true
+      }
+
+      await AsyncStorage.setItem(WORKOUT_STORAGE_KEY, JSON.stringify(updatedWorkouts))
+      return true
+    } catch (error) {
+      console.error('Error applying exercise max change to workouts:', error)
       return false
     }
   }


### PR DESCRIPTION
## Summary

When a 1RM changed, percentage-based workouts kept **stored absolute weight** but anything that derived % from `weight ÷ current max` showed a **different %**. This updates linked workouts whenever an exercise max is saved so **% stays the same** and **working weight** follows the new max.

## Changes

- `WorkoutService.applyExerciseMaxChangeToWorkouts` — standard %, per-set, and legacy max-only rows
- `ExerciseMaxFormModal` — call sync after max update (with a small error alert if sync fails)
- `absoluteWeightToMaxPercent` in `ExerciseMax` — shared helper; form uses it instead of a duplicate

## Testing

- Jest: `ExerciseMax` + `WorkoutService` (including new `applyExerciseMaxChangeToWorkouts` cases)