### PR TITLE
feat: Workout bank

### DIFF
--- a/magni/__tests__/components/workouts/WorkoutLibraryModal.test.tsx
+++ b/magni/__tests__/components/workouts/WorkoutLibraryModal.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+import { WorkoutLibraryModal } from '../../../components/workouts/WorkoutLibraryModal'
+import { WorkoutDay } from '../../../lib/models/WorkoutDay'
+import { BankedWorkout } from '../../../lib/models/BankedWorkout'
+
+jest.mock('../../../hooks/useThemeColors', () => ({
+  useThemeColors: () => ({
+    primary: '#007AFF',
+    warning: '#FF9500',
+    error: '#FF3B30',
+    background: '#F2F2F7',
+    surface: '#FFFFFF',
+    text: {
+      primary: '#000000',
+      secondary: '#3C3C43',
+      tertiary: '#3C3C4399',
+    },
+    border: '#C6C6C8',
+  }),
+}))
+
+const buildActive = (overrides: Partial<WorkoutDay> = {}): WorkoutDay => ({
+  id: 'active-1',
+  name: 'Bench Press',
+  weight: 135,
+  sets: 3,
+  reps: 10,
+  day: 1,
+  dayOrder: 0,
+  ...overrides,
+})
+
+const buildBanked = (overrides: Partial<BankedWorkout> = {}): BankedWorkout => ({
+  id: 'bank-1',
+  sharedWorkoutId: 'sync-1',
+  name: 'Squat',
+  weight: 225,
+  sets: 5,
+  reps: 5,
+  bankedAt: '2024-06-01T12:00:00.000Z',
+  ...overrides,
+})
+
+const renderModal = (overrides: Partial<React.ComponentProps<typeof WorkoutLibraryModal>> = {}) => {
+  const props = {
+    activeWorkouts: [buildActive()] as WorkoutDay[],
+    bankedWorkouts: [buildBanked()] as BankedWorkout[],
+    onSelectActive: jest.fn(),
+    onSelectBanked: jest.fn(),
+    onClose: jest.fn(),
+    onDeleteBanked: jest.fn(),
+    ...overrides,
+  }
+  return { ...render(<WorkoutLibraryModal {...props} />), props }
+}
+
+describe('WorkoutLibraryModal', () => {
+  describe('Rendering', () => {
+    it('shows both active and banked workouts by default', () => {
+      const { getByText } = renderModal()
+      expect(getByText('Bench Press')).toBeTruthy()
+      expect(getByText('Squat')).toBeTruthy()
+    })
+
+    it('labels active and banked workouts with badges', () => {
+      const { getAllByText } = renderModal()
+      // 'Program' and 'Bank' appear both as filter chips and as item badges.
+      expect(getAllByText('Program').length).toBeGreaterThanOrEqual(2)
+      expect(getAllByText('Bank').length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('shows the saved-on metadata for banked entries', () => {
+      const { getByText } = renderModal()
+      expect(getByText(/Saved/)).toBeTruthy()
+    })
+  })
+
+  describe('Search filter', () => {
+    it('filters entries by name (case-insensitive)', () => {
+      const { getByPlaceholderText, queryByText } = renderModal({
+        activeWorkouts: [buildActive({ name: 'Bench Press' })],
+        bankedWorkouts: [buildBanked({ name: 'Squat' })],
+      })
+
+      const search = getByPlaceholderText('Search by name')
+      fireEvent.changeText(search, 'squa')
+
+      expect(queryByText('Squat')).toBeTruthy()
+      expect(queryByText('Bench Press')).toBeNull()
+    })
+
+    it('shows a search-specific empty message when nothing matches', () => {
+      const { getByPlaceholderText, getByText } = renderModal()
+      fireEvent.changeText(getByPlaceholderText('Search by name'), 'nothingmatches')
+      expect(getByText('No workouts match "nothingmatches"')).toBeTruthy()
+    })
+  })
+
+  describe('Source filter', () => {
+    it('hides banked workouts when filter is set to Program', () => {
+      const { getByLabelText, queryByText, getAllByText } = renderModal()
+      fireEvent.press(getByLabelText('Filter by Program'))
+
+      expect(queryByText('Squat')).toBeNull()
+      // 'Bench Press' is shown along with its 'Program' badge
+      expect(getAllByText('Bench Press').length).toBeGreaterThan(0)
+    })
+
+    it('hides active workouts when filter is set to Bank', () => {
+      const { getByLabelText, getByText, queryByText } = renderModal()
+      fireEvent.press(getByLabelText('Filter by Bank'))
+
+      expect(queryByText('Bench Press')).toBeNull()
+      expect(getByText('Squat')).toBeTruthy()
+    })
+
+    it('shows source-specific empty state for Bank when bank is empty', () => {
+      const { getByLabelText, getByText, queryByText } = renderModal({ bankedWorkouts: [] })
+      fireEvent.press(getByLabelText('Filter by Bank'))
+      expect(queryByText('Squat')).toBeNull()
+      expect(getByText('Your workout bank is empty')).toBeTruthy()
+    })
+  })
+
+  describe('Selection', () => {
+    it('calls onSelectActive when an active workout is pressed', () => {
+      const onSelectActive = jest.fn()
+      const onSelectBanked = jest.fn()
+      const active = buildActive()
+      const { getByLabelText } = renderModal({
+        activeWorkouts: [active],
+        bankedWorkouts: [],
+        onSelectActive,
+        onSelectBanked,
+      })
+
+      fireEvent.press(getByLabelText(`Add ${active.name} from program`))
+
+      expect(onSelectActive).toHaveBeenCalledWith(active)
+      expect(onSelectBanked).not.toHaveBeenCalled()
+    })
+
+    it('calls onSelectBanked when a banked workout is pressed', () => {
+      const onSelectActive = jest.fn()
+      const onSelectBanked = jest.fn()
+      const banked = buildBanked()
+      const { getByLabelText } = renderModal({
+        activeWorkouts: [],
+        bankedWorkouts: [banked],
+        onSelectActive,
+        onSelectBanked,
+      })
+
+      fireEvent.press(getByLabelText(`Add ${banked.name} from bank`))
+
+      expect(onSelectBanked).toHaveBeenCalledWith(banked)
+      expect(onSelectActive).not.toHaveBeenCalled()
+    })
+
+    it('calls onDeleteBanked when the remove button is pressed', () => {
+      const onDeleteBanked = jest.fn()
+      const banked = buildBanked()
+      const { getByLabelText } = renderModal({
+        activeWorkouts: [],
+        bankedWorkouts: [banked],
+        onDeleteBanked,
+      })
+
+      fireEvent.press(getByLabelText(`Remove ${banked.name} from bank`))
+      expect(onDeleteBanked).toHaveBeenCalledWith(banked)
+    })
+  })
+
+  describe('Close', () => {
+    it('calls onClose when the close button is pressed', () => {
+      const onClose = jest.fn()
+      const { getByLabelText } = renderModal({ onClose })
+      fireEvent.press(getByLabelText('Close workout library'))
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/magni/__tests__/lib/models/BankedWorkout.test.ts
+++ b/magni/__tests__/lib/models/BankedWorkout.test.ts
@@ -1,0 +1,198 @@
+import {
+  BankedWorkout,
+  BankedWorkoutConverter,
+  BankedWorkoutValidator,
+  bankedWorkoutFromWorkout,
+  filterBankForActivePrograms,
+  getBankedSyncGroupId,
+} from '../../../lib/models/BankedWorkout'
+import { Workout, WORKOUT_CONSTRAINTS } from '../../../lib/models/Workout'
+
+const baseBanked = (overrides: Partial<BankedWorkout> = {}): BankedWorkout => ({
+  id: 'bank-1',
+  sharedWorkoutId: 'sync-1',
+  name: 'Bench Press',
+  weight: 135,
+  sets: 3,
+  reps: 10,
+  bankedAt: '2024-06-01T12:00:00.000Z',
+  ...overrides,
+})
+
+describe('BankedWorkout Model', () => {
+  describe('BankedWorkoutConverter', () => {
+    it('round-trips through toData/fromData', () => {
+      const banked = baseBanked({
+        notes: 'Use spotter',
+        setDetails: [
+          { weight: 135, reps: 10 },
+          { weight: 145, reps: 8 },
+        ],
+        exerciseMaxId: 'max-1',
+        maxPercentage: 67,
+      })
+
+      const result = BankedWorkoutConverter.fromData(BankedWorkoutConverter.toData(banked))
+      expect(result).toEqual(banked)
+    })
+  })
+
+  describe('BankedWorkoutValidator', () => {
+    it('accepts a valid banked workout', () => {
+      expect(() => BankedWorkoutValidator.validate(baseBanked())).not.toThrow()
+    })
+
+    it.each([
+      ['empty id', { id: '' }],
+      ['empty name', { name: '' }],
+      ['missing bankedAt', { bankedAt: '' }],
+      ['invalid bankedAt', { bankedAt: 'not-a-date' }],
+    ])('throws when %s', (_label, overrides) => {
+      expect(() => BankedWorkoutValidator.validate(baseBanked(overrides))).toThrow()
+    })
+
+    it('throws when notes exceed length limit', () => {
+      const banked = baseBanked({
+        notes: 'x'.repeat(WORKOUT_CONSTRAINTS.NOTES_LENGTH_LIMIT + 1),
+      })
+      expect(() => BankedWorkoutValidator.validate(banked)).toThrow(/Notes/)
+    })
+
+    it('throws when weight exceeds limit', () => {
+      const banked = baseBanked({ weight: WORKOUT_CONSTRAINTS.WEIGHT_LIMIT + 1 })
+      expect(() => BankedWorkoutValidator.validate(banked)).toThrow(/Weight/)
+    })
+
+    it('throws when a setDetail entry exceeds limits', () => {
+      const banked = baseBanked({
+        setDetails: [{ weight: WORKOUT_CONSTRAINTS.WEIGHT_LIMIT + 1, reps: 1 }],
+      })
+      expect(() => BankedWorkoutValidator.validate(banked)).toThrow(/Weight/)
+    })
+
+    describe('hasSetDetails', () => {
+      it('returns true when set details are present', () => {
+        expect(
+          BankedWorkoutValidator.hasSetDetails(baseBanked({ setDetails: [{ weight: 1, reps: 1 }] })),
+        ).toBe(true)
+      })
+
+      it('returns false when set details are missing or empty', () => {
+        expect(BankedWorkoutValidator.hasSetDetails(baseBanked())).toBe(false)
+        expect(BankedWorkoutValidator.hasSetDetails(baseBanked({ setDetails: [] }))).toBe(false)
+      })
+    })
+  })
+
+  describe('bankedWorkoutFromWorkout', () => {
+    const workout: Workout = {
+      id: 'w-1',
+      name: 'Squat',
+      weight: 225,
+      sets: 5,
+      reps: 5,
+      notes: 'Belt on',
+      setDetails: [{ weight: 225, reps: 5 }],
+      exerciseMaxId: 'max-squat',
+      maxPercentage: 80,
+    }
+
+    it('preserves persisted fields and strips day-specific data', () => {
+      const banked = bankedWorkoutFromWorkout(workout, {
+        id: 'fixed-id',
+        bankedAt: '2024-06-15T08:30:00.000Z',
+      })
+
+      expect(banked).toMatchObject({
+        id: 'fixed-id',
+        sharedWorkoutId: 'w-1',
+        name: 'Squat',
+        weight: 225,
+        sets: 5,
+        reps: 5,
+        notes: 'Belt on',
+        setDetails: [{ weight: 225, reps: 5 }],
+        exerciseMaxId: 'max-squat',
+        maxPercentage: 80,
+        bankedAt: '2024-06-15T08:30:00.000Z',
+      })
+    })
+
+    it('uses sharedWorkoutId when present rather than id', () => {
+      const banked = bankedWorkoutFromWorkout({ ...workout, sharedWorkoutId: 'shared-99' })
+      expect(banked.sharedWorkoutId).toBe('shared-99')
+    })
+
+    it('deep-copies set details so later mutation does not affect bank', () => {
+      const original = {
+        ...workout,
+        setDetails: [{ weight: 100, reps: 5 }],
+      }
+      const banked = bankedWorkoutFromWorkout(original)
+
+      original.setDetails![0].weight = 999
+      expect(banked.setDetails?.[0].weight).toBe(100)
+    })
+
+    it('falls back to a generated id and current timestamp', () => {
+      const banked = bankedWorkoutFromWorkout(workout)
+      expect(banked.id).toMatch(/^bank-/)
+      expect(Number.isNaN(Date.parse(banked.bankedAt))).toBe(false)
+    })
+  })
+
+  describe('getBankedSyncGroupId', () => {
+    it('returns sharedWorkoutId when present', () => {
+      expect(getBankedSyncGroupId(baseBanked({ sharedWorkoutId: 'sync-9' }))).toBe('sync-9')
+    })
+
+    it('falls back to id when sharedWorkoutId is missing', () => {
+      expect(
+        getBankedSyncGroupId(baseBanked({ id: 'lone-1', sharedWorkoutId: undefined })),
+      ).toBe('lone-1')
+    })
+  })
+
+  describe('filterBankForActivePrograms', () => {
+    const buildWorkout = (overrides: Partial<Workout> = {}): Workout => ({
+      id: 'w-1',
+      name: 'Bench Press',
+      weight: 135,
+      sets: 3,
+      reps: 10,
+      ...overrides,
+    })
+
+    it('returns the original list when there are no active workouts', () => {
+      const banked = [baseBanked({ id: 'b-1' }), baseBanked({ id: 'b-2', sharedWorkoutId: 'sync-2' })]
+      expect(filterBankForActivePrograms(banked, [])).toEqual(banked)
+    })
+
+    it('hides banked entries whose sync group is still active', () => {
+      const banked = [
+        baseBanked({ id: 'b-active', sharedWorkoutId: 'shared-1' }),
+        baseBanked({ id: 'b-orphan', sharedWorkoutId: 'shared-2' }),
+      ]
+      const active: Workout[] = [
+        buildWorkout({ id: 'w-day1', sharedWorkoutId: 'shared-1' }),
+        buildWorkout({ id: 'w-day2', sharedWorkoutId: 'shared-1' }),
+      ]
+      const result = filterBankForActivePrograms(banked, active)
+      expect(result.map(b => b.id)).toEqual(['b-orphan'])
+    })
+
+    it('matches on sharedWorkoutId OR id (treats unlinked active workouts as their own group)', () => {
+      const banked = [baseBanked({ id: 'standalone-1', sharedWorkoutId: undefined })]
+      const active: Workout[] = [buildWorkout({ id: 'standalone-1' })]
+      expect(filterBankForActivePrograms(banked, active)).toEqual([])
+    })
+
+    it('does not mutate inputs', () => {
+      const banked = [baseBanked({ id: 'a' }), baseBanked({ id: 'b', sharedWorkoutId: 'group' })]
+      const active: Workout[] = [buildWorkout({ sharedWorkoutId: 'group' })]
+      const snapshot = JSON.stringify(banked)
+      filterBankForActivePrograms(banked, active)
+      expect(JSON.stringify(banked)).toBe(snapshot)
+    })
+  })
+})

--- a/magni/__tests__/lib/services/WorkoutBankService.test.ts
+++ b/magni/__tests__/lib/services/WorkoutBankService.test.ts
@@ -1,0 +1,207 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  workoutBankService,
+  WORKOUT_BANK_STORAGE_KEY,
+} from '../../../lib/services/WorkoutBankService'
+import { BankedWorkout } from '../../../lib/models/BankedWorkout'
+import { Workout } from '../../../lib/models/Workout'
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>
+const mockGetItem = mockAsyncStorage.getItem as jest.MockedFunction<typeof mockAsyncStorage.getItem>
+const mockSetItem = mockAsyncStorage.setItem as jest.MockedFunction<typeof mockAsyncStorage.setItem>
+
+const buildBanked = (overrides: Partial<BankedWorkout> = {}): BankedWorkout => ({
+  id: 'bank-1',
+  sharedWorkoutId: 'sync-1',
+  name: 'Bench Press',
+  weight: 135,
+  sets: 3,
+  reps: 10,
+  bankedAt: '2024-06-01T12:00:00.000Z',
+  ...overrides,
+})
+
+const buildWorkout = (overrides: Partial<Workout> = {}): Workout => ({
+  id: 'workout-1',
+  name: 'Bench Press',
+  weight: 135,
+  sets: 3,
+  reps: 10,
+  ...overrides,
+})
+
+const readLastSetItemPayload = (): BankedWorkout[] => {
+  const calls = mockSetItem.mock.calls
+  const last = calls[calls.length - 1]
+  return JSON.parse(last[1] as string) as BankedWorkout[]
+}
+
+const originalConsoleError = console.error
+beforeAll(() => {
+  console.error = jest.fn()
+})
+afterAll(() => {
+  console.error = originalConsoleError
+})
+
+describe('WorkoutBankService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getBankedWorkouts', () => {
+    it('returns empty array when storage is empty', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      const result = await workoutBankService.getBankedWorkouts()
+      expect(result).toEqual([])
+      expect(mockGetItem).toHaveBeenCalledWith(WORKOUT_BANK_STORAGE_KEY)
+    })
+
+    it('returns banked workouts sorted by bankedAt descending', async () => {
+      const banked: BankedWorkout[] = [
+        buildBanked({ id: 'old', bankedAt: '2024-01-01T00:00:00.000Z' }),
+        buildBanked({ id: 'newest', bankedAt: '2024-06-01T00:00:00.000Z' }),
+        buildBanked({ id: 'mid', bankedAt: '2024-03-01T00:00:00.000Z' }),
+      ]
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(banked))
+
+      const result = await workoutBankService.getBankedWorkouts()
+      expect(result.map(b => b.id)).toEqual(['newest', 'mid', 'old'])
+    })
+
+    it('returns empty array when storage rejects', async () => {
+      mockGetItem.mockRejectedValueOnce(new Error('boom'))
+      const result = await workoutBankService.getBankedWorkouts()
+      expect(result).toEqual([])
+    })
+
+    it('returns empty array when payload is malformed JSON', async () => {
+      mockGetItem.mockResolvedValueOnce('not-json')
+      const result = await workoutBankService.getBankedWorkouts()
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('bankWorkout', () => {
+    it('persists a snapshot of the workout', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const result = await workoutBankService.bankWorkout(
+        buildWorkout({ notes: 'Watch elbows' }),
+      )
+
+      expect(result).toBe(true)
+      const stored = readLastSetItemPayload()
+      expect(stored).toHaveLength(1)
+      expect(stored[0]).toMatchObject({
+        sharedWorkoutId: 'workout-1',
+        name: 'Bench Press',
+        weight: 135,
+        sets: 3,
+        reps: 10,
+        notes: 'Watch elbows',
+      })
+      expect(stored[0].bankedAt).toBeTruthy()
+    })
+
+    it('replaces an existing entry with the same sharedWorkoutId', async () => {
+      const existing = buildBanked({
+        id: 'old',
+        sharedWorkoutId: 'workout-1',
+        weight: 100,
+        bankedAt: '2024-01-01T00:00:00.000Z',
+      })
+      const unrelated = buildBanked({
+        id: 'other',
+        sharedWorkoutId: 'workout-2',
+        bankedAt: '2024-02-01T00:00:00.000Z',
+      })
+      mockGetItem.mockResolvedValueOnce(JSON.stringify([existing, unrelated]))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      await workoutBankService.bankWorkout(buildWorkout({ id: 'workout-1', weight: 200 }))
+
+      const stored = readLastSetItemPayload()
+      expect(stored.find(b => b.id === 'old')).toBeUndefined()
+      expect(stored.find(b => b.sharedWorkoutId === 'workout-2')?.id).toBe('other')
+      const replacement = stored.find(b => b.sharedWorkoutId === 'workout-1')
+      expect(replacement?.weight).toBe(200)
+    })
+
+    it('preserves explicit sharedWorkoutId from the source workout', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      await workoutBankService.bankWorkout(
+        buildWorkout({ id: 'workout-1', sharedWorkoutId: 'shared-99' }),
+      )
+
+      const stored = readLastSetItemPayload()
+      expect(stored[0].sharedWorkoutId).toBe('shared-99')
+    })
+
+    it('returns false when validation fails', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      const result = await workoutBankService.bankWorkout(
+        buildWorkout({ name: '' }),
+      )
+      expect(result).toBe(false)
+      expect(mockSetItem).not.toHaveBeenCalled()
+    })
+
+    it('returns false when AsyncStorage write fails', async () => {
+      mockGetItem.mockResolvedValueOnce(null)
+      mockSetItem.mockRejectedValueOnce(new Error('disk full'))
+      const result = await workoutBankService.bankWorkout(buildWorkout())
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('removeBankedWorkout', () => {
+    it('removes only the matching entry', async () => {
+      const banked = [
+        buildBanked({ id: 'keep-1', bankedAt: '2024-02-01T00:00:00.000Z' }),
+        buildBanked({ id: 'remove-me', bankedAt: '2024-03-01T00:00:00.000Z' }),
+        buildBanked({ id: 'keep-2', bankedAt: '2024-04-01T00:00:00.000Z' }),
+      ]
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(banked))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const result = await workoutBankService.removeBankedWorkout('remove-me')
+
+      expect(result).toBe(true)
+      const stored = readLastSetItemPayload()
+      expect(stored.map(b => b.id).sort()).toEqual(['keep-1', 'keep-2'])
+    })
+
+    it('returns false when storage write fails', async () => {
+      mockGetItem.mockResolvedValueOnce(JSON.stringify([buildBanked()]))
+      mockSetItem.mockRejectedValueOnce(new Error('boom'))
+
+      const result = await workoutBankService.removeBankedWorkout('bank-1')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('clearBank', () => {
+    it('writes an empty array to storage', async () => {
+      mockSetItem.mockResolvedValueOnce(undefined)
+      const result = await workoutBankService.clearBank()
+      expect(result).toBe(true)
+      expect(mockSetItem).toHaveBeenCalledWith(WORKOUT_BANK_STORAGE_KEY, JSON.stringify([]))
+    })
+
+    it('returns false when storage write fails', async () => {
+      mockSetItem.mockRejectedValueOnce(new Error('boom'))
+      const result = await workoutBankService.clearBank()
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('Singleton', () => {
+    it('returns the same instance on repeated imports', () => {
+      expect(workoutBankService).toBe(workoutBankService)
+    })
+  })
+})

--- a/magni/__tests__/lib/services/WorkoutService.test.ts
+++ b/magni/__tests__/lib/services/WorkoutService.test.ts
@@ -407,6 +407,38 @@ describe('WorkoutService', () => {
     })
   })
 
+  describe('removeWorkoutsByIds', () => {
+    it('removes multiple workouts in one write', async () => {
+      const existingWorkouts = [
+        createMockWorkoutDay({ id: 'a', name: 'A' }),
+        createMockWorkoutDay({ id: 'b', name: 'B' }),
+        createMockWorkoutDay({ id: 'c', name: 'C' }),
+      ]
+      mockGetItem.mockResolvedValueOnce(JSON.stringify(existingWorkouts))
+      mockSetItem.mockResolvedValueOnce(undefined)
+
+      const result = await workoutService.removeWorkoutsByIds(['a', 'c'])
+
+      expect(result).toBe(true)
+      const stored = JSON.parse(mockSetItem.mock.calls[mockSetItem.mock.calls.length - 1][1] as string)
+      expect(stored).toHaveLength(1)
+      expect(stored[0].id).toBe('b')
+    })
+
+    it('returns true when ids is empty without touching storage', async () => {
+      const result = await workoutService.removeWorkoutsByIds([])
+      expect(result).toBe(true)
+      expect(mockGetItem).not.toHaveBeenCalled()
+      expect(mockSetItem).not.toHaveBeenCalled()
+    })
+
+    it('returns false when setItem fails', async () => {
+      mockGetItem.mockResolvedValueOnce(JSON.stringify([createMockWorkoutDay({ id: 'x' })]))
+      mockSetItem.mockRejectedValueOnce(new Error('Set item error'))
+      expect(await workoutService.removeWorkoutsByIds(['x'])).toBe(false)
+    })
+  })
+
   describe('updateWorkout', () => {
     it('updates workout successfully', async () => {
       const existingWorkouts = [

--- a/magni/components/workouts/WorkoutLibraryModal.tsx
+++ b/magni/components/workouts/WorkoutLibraryModal.tsx
@@ -1,0 +1,368 @@
+import React, { useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from 'react-native'
+import { WorkoutDay } from '../../lib/models/WorkoutDay'
+import { BankedWorkout } from '../../lib/models/BankedWorkout'
+import { useThemeColors } from '../../hooks/useThemeColors'
+import { BORDER_RADIUS, SPACING, TYPOGRAPHY } from '../../lib/constants/ui'
+
+export type WorkoutLibrarySource = 'all' | 'active' | 'bank'
+
+export interface ActiveLibraryEntry {
+  kind: 'active';
+  key: string;
+  workout: WorkoutDay;
+}
+
+export interface BankedLibraryEntry {
+  kind: 'banked';
+  key: string;
+  workout: BankedWorkout;
+}
+
+export type WorkoutLibraryEntry = ActiveLibraryEntry | BankedLibraryEntry
+
+interface WorkoutLibraryModalProps {
+  activeWorkouts: WorkoutDay[];
+  bankedWorkouts: BankedWorkout[];
+  onSelectActive: (workout: WorkoutDay) => void;
+  onSelectBanked: (workout: BankedWorkout) => void;
+  onClose: () => void;
+  onDeleteBanked?: (workout: BankedWorkout) => void;
+  initialSource?: WorkoutLibrarySource;
+}
+
+const FILTER_OPTIONS: { id: WorkoutLibrarySource; label: string }[] = [
+  { id: 'all', label: 'All' },
+  { id: 'active', label: 'Program' },
+  { id: 'bank', label: 'Bank' },
+]
+
+const formatBankedAt = (iso: string): string => {
+  const ts = Date.parse(iso)
+  if (!Number.isFinite(ts)) return ''
+  const date = new Date(ts)
+  return date.toLocaleDateString()
+}
+
+export const WorkoutLibraryModal: React.FC<WorkoutLibraryModalProps> = ({
+  activeWorkouts,
+  bankedWorkouts,
+  onSelectActive,
+  onSelectBanked,
+  onClose,
+  onDeleteBanked,
+  initialSource = 'all',
+}) => {
+  const colors = useThemeColors()
+  const [search, setSearch] = useState('')
+  const [source, setSource] = useState<WorkoutLibrarySource>(initialSource)
+
+  const entries = useMemo<WorkoutLibraryEntry[]>(() => {
+    const query = search.trim().toLowerCase()
+    const matches = (name: string) => query === '' || name.toLowerCase().includes(query)
+
+    const activeEntries: WorkoutLibraryEntry[] = activeWorkouts
+      .filter(w => matches(w.name))
+      .map(w => ({ kind: 'active', key: `active-${w.id}`, workout: w }))
+
+    const bankedEntries: WorkoutLibraryEntry[] = bankedWorkouts
+      .filter(w => matches(w.name))
+      .map(w => ({ kind: 'banked', key: `banked-${w.id}`, workout: w }))
+
+    if (source === 'active') return activeEntries
+    if (source === 'bank') return bankedEntries
+    return [...activeEntries, ...bankedEntries]
+  }, [activeWorkouts, bankedWorkouts, search, source])
+
+  const renderEmpty = () => {
+    let message = 'No workouts found'
+    if (source === 'bank') message = 'Your workout bank is empty'
+    if (source === 'active') message = 'No existing workouts available'
+    if (search.trim() !== '') message = `No workouts match "${search.trim()}"`
+
+    return (
+      <Text style={[styles.emptyText, { color: colors.text.secondary }]}>
+        {message}
+      </Text>
+    )
+  }
+
+  const renderItem = (entry: WorkoutLibraryEntry) => {
+    const workout = entry.workout
+    const subtitleParts = [
+      `${workout.weight} lb`,
+      `${workout.sets} sets`,
+      `${workout.reps} reps`,
+    ]
+    const isBanked = entry.kind === 'banked'
+
+    return (
+      <View
+        key={entry.key}
+        style={[
+          styles.item,
+          { backgroundColor: colors.background, borderColor: colors.border },
+        ]}
+      >
+        <TouchableOpacity
+          style={styles.itemBody}
+          onPress={() =>
+            isBanked
+              ? onSelectBanked(entry.workout)
+              : onSelectActive(entry.workout)
+          }
+          accessibilityLabel={`Add ${workout.name} from ${isBanked ? 'bank' : 'program'}`}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.itemName, { color: colors.text.primary }]}>
+            {workout.name}
+          </Text>
+          <Text style={[styles.itemDetails, { color: colors.text.secondary }]}>
+            {subtitleParts.join(' • ')}
+          </Text>
+          {isBanked && (
+            <Text style={[styles.itemMeta, { color: colors.text.tertiary }]}>
+              Saved {formatBankedAt(entry.workout.bankedAt)}
+            </Text>
+          )}
+        </TouchableOpacity>
+        <View
+          style={[
+            styles.badgeColumn,
+            { paddingRight: isBanked ? SPACING.xs : SPACING.lg },
+          ]}
+        >
+          <View
+            style={[
+              styles.badge,
+              {
+                backgroundColor: isBanked ? colors.warning : colors.primary,
+              },
+            ]}
+          >
+            <Text style={styles.badgeText}>
+              {isBanked ? 'Bank' : 'Program'}
+            </Text>
+          </View>
+        </View>
+        {isBanked && onDeleteBanked && (
+          <TouchableOpacity
+            style={styles.deleteButton}
+            onPress={() => onDeleteBanked(entry.workout)}
+            accessibilityLabel={`Remove ${workout.name} from bank`}
+            accessibilityRole="button"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Text style={[styles.deleteText, { color: colors.error }]}>×</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.overlay}>
+      <View style={[styles.modal, { backgroundColor: colors.surface }]}>
+        <View style={[styles.header, { borderBottomColor: colors.border }]}>
+          <Text style={[styles.title, { color: colors.text.primary }]}>
+            Workout Library
+          </Text>
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={onClose}
+            accessibilityLabel="Close workout library"
+            accessibilityRole="button"
+          >
+            <Text style={[styles.closeText, { color: colors.text.secondary }]}>✕</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.controls}>
+          <TextInput
+            style={[
+              styles.searchInput,
+              {
+                backgroundColor: colors.background,
+                color: colors.text.primary,
+                borderColor: colors.border,
+              },
+            ]}
+            value={search}
+            onChangeText={setSearch}
+            placeholder="Search by name"
+            placeholderTextColor={colors.text.tertiary}
+            accessibilityLabel="Search workouts"
+          />
+
+          <View style={styles.filterRow}>
+            {FILTER_OPTIONS.map(option => {
+              const isSelected = source === option.id
+              return (
+                <TouchableOpacity
+                  key={option.id}
+                  onPress={() => setSource(option.id)}
+                  style={[
+                    styles.filterChip,
+                    {
+                      backgroundColor: isSelected
+                        ? colors.primary
+                        : colors.background,
+                      borderColor: isSelected ? colors.primary : colors.border,
+                    },
+                  ]}
+                  accessibilityLabel={`Filter by ${option.label}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                >
+                  <Text
+                    style={[
+                      styles.filterChipText,
+                      { color: isSelected ? '#fff' : colors.text.primary },
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </TouchableOpacity>
+              )
+            })}
+          </View>
+        </View>
+
+        <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
+          {entries.length === 0 ? renderEmpty() : entries.map(renderItem)}
+        </ScrollView>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: SPACING.xl,
+  },
+  modal: {
+    borderRadius: BORDER_RADIUS.lg,
+    width: '100%',
+    maxHeight: '85%',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: TYPOGRAPHY.sizes.lg,
+    fontWeight: TYPOGRAPHY.weights.bold,
+  },
+  closeButton: {
+    padding: SPACING.sm,
+  },
+  closeText: {
+    fontSize: TYPOGRAPHY.sizes.lg,
+  },
+  controls: {
+    paddingHorizontal: SPACING.md,
+    paddingTop: SPACING.md,
+    gap: SPACING.sm,
+  },
+  searchInput: {
+    borderWidth: 1,
+    borderRadius: BORDER_RADIUS.md,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    fontSize: TYPOGRAPHY.sizes.md,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    gap: SPACING.sm,
+  },
+  filterChip: {
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+  },
+  filterChipText: {
+    fontSize: TYPOGRAPHY.sizes.sm,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+  },
+  list: {
+    paddingHorizontal: SPACING.md,
+  },
+  listContent: {
+    paddingVertical: SPACING.md,
+    gap: SPACING.sm,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: BORDER_RADIUS.md,
+    overflow: 'hidden',
+  },
+  itemBody: {
+    flex: 1,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.md,
+  },
+  badgeColumn: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+  },
+  itemName: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    fontWeight: TYPOGRAPHY.weights.bold,
+    marginBottom: SPACING.xs,
+  },
+  badge: {
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.sm,
+  },
+  badgeText: {
+    color: '#fff',
+    fontSize: TYPOGRAPHY.sizes.xs,
+    fontWeight: TYPOGRAPHY.weights.semibold,
+  },
+  itemDetails: {
+    fontSize: TYPOGRAPHY.sizes.sm,
+  },
+  itemMeta: {
+    fontSize: TYPOGRAPHY.sizes.xs,
+    marginTop: SPACING.xs,
+  },
+  deleteButton: {
+    alignSelf: 'stretch',
+    paddingHorizontal: SPACING.md,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteText: {
+    fontSize: TYPOGRAPHY.sizes.xl,
+    fontWeight: TYPOGRAPHY.weights.bold,
+  },
+  emptyText: {
+    fontSize: TYPOGRAPHY.sizes.md,
+    textAlign: 'center',
+    paddingVertical: SPACING.xl,
+  },
+})

--- a/magni/components/workouts/WorkoutsConfigure.tsx
+++ b/magni/components/workouts/WorkoutsConfigure.tsx
@@ -9,8 +9,11 @@ import {
 } from 'react-native'
 import { WorkoutDay } from '../../lib/models/WorkoutDay'
 import { getSyncGroupId } from '../../lib/models/Workout'
+import { BankedWorkout, filterBankForActivePrograms } from '../../lib/models/BankedWorkout'
 import { workoutService } from '../../lib/services/WorkoutService'
+import { workoutBankService } from '../../lib/services/WorkoutBankService'
 import { WorkoutCreateUpdateForm } from './WorkoutCreateUpdateForm'
+import { WorkoutLibraryModal } from './WorkoutLibraryModal'
 import { useThemeColors } from '../../hooks/useThemeColors'
 import { confirm, confirmAlert, confirmDelete } from '../../utils/confirm'
 
@@ -21,23 +24,26 @@ interface WorkoutsConfigureProps {
 export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
   const colors = useThemeColors()
   const [workouts, setWorkouts] = useState<WorkoutDay[]>([])
+  const [bankedWorkouts, setBankedWorkouts] = useState<BankedWorkout[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [editingWorkout, setEditingWorkout] = useState<WorkoutDay | undefined>()
   const [showForm, setShowForm] = useState(false)
-  const [showExistingWorkoutSelector, setShowExistingWorkoutSelector] = useState(false)
+  const [showLibrary, setShowLibrary] = useState(false)
   const [selectedDay, setSelectedDay] = useState(1)
   const [totalDays, setTotalDays] = useState(0)
 
   const loadWorkouts = async () => {
     try {
       setIsLoading(true)
-      const [workoutsData, uniqueDays] = await Promise.all([
+      const [workoutsData, uniqueDays, bankedData] = await Promise.all([
         workoutService.getWorkouts(),
         workoutService.getUniqueDays(),
+        workoutBankService.getBankedWorkouts(),
       ])
-      
+
       setWorkouts(workoutsData)
       setTotalDays(uniqueDays)
+      setBankedWorkouts(bankedData)
     } catch (error) {
       console.error('Error loading workouts:', error)
       confirmAlert('Error', 'Failed to load workouts')
@@ -55,8 +61,110 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
     setShowForm(true)
   }
 
-  const handleAddExistingWorkout = () => {
-    setShowExistingWorkoutSelector(true)
+  const handleOpenLibrary = () => {
+    setShowLibrary(true)
+  }
+
+  const handleSaveWorkoutToBank = (workout: WorkoutDay) => {
+    const syncGroupId = getSyncGroupId(workout)
+    const linkedInstances = workouts.filter(w => getSyncGroupId(w) === syncGroupId)
+    const otherDays = Array.from(
+      new Set(linkedInstances.filter(w => w.id !== workout.id).map(w => w.day)),
+    ).sort((a, b) => a - b)
+
+    let daysList = `Day ${workout.day}`
+    if (otherDays.length === 1) {
+      daysList = `Days ${workout.day} and ${otherDays[0]}`
+    } else if (otherDays.length > 1) {
+      const allDays = [workout.day, ...otherDays].sort((a, b) => a - b)
+      daysList = `Days ${allDays.slice(0, -1).join(', ')} and ${allDays[allDays.length - 1]}`
+    }
+
+    const message = otherDays.length === 0
+      ? `Save "${workout.name}" to your workout bank for later? It will be removed from Day ${workout.day} but its weights, reps, and notes will be preserved.`
+      : `"${workout.name}" is also scheduled in ${otherDays.length === 1 ? `Day ${otherDays[0]}` : `Days ${otherDays.join(', ')}`}. Saving to your bank will remove it from ${daysList}. Its weights, reps, and notes will be preserved.`
+
+    confirm(
+      'Save to Bank?',
+      message,
+      [
+        { text: 'Cancel', style: 'cancel', onPress: () => {} },
+        {
+          text: 'Save to Bank',
+          style: 'default',
+          onPress: async () => {
+            try {
+              const banked = await workoutBankService.bankWorkout(workout)
+              if (!banked) {
+                confirmAlert('Error', 'Failed to save workout to bank')
+                return
+              }
+              const idsToRemove = linkedInstances.map(w => w.id)
+              const removed = await workoutService.removeWorkoutsByIds(idsToRemove)
+              if (!removed) {
+                confirmAlert(
+                  'Error',
+                  'Saved to bank but failed to remove all copies from your program. Check other days and remove duplicates manually.',
+                )
+              }
+              await loadWorkouts()
+            } catch (error) {
+              console.error('Error saving workout to bank:', error)
+              confirmAlert('Error', 'Failed to save workout to bank')
+            }
+          },
+        },
+      ],
+    )
+  }
+
+  const handleSelectBankedWorkout = async (banked: BankedWorkout) => {
+    try {
+      const dayWorkouts = getWorkoutsForDay(selectedDay)
+      const newWorkout: WorkoutDay = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        sharedWorkoutId: banked.sharedWorkoutId,
+        day: selectedDay,
+        dayOrder: dayWorkouts.length + 1,
+        name: banked.name,
+        weight: banked.weight,
+        sets: banked.sets,
+        reps: banked.reps,
+        notes: banked.notes,
+        setDetails: banked.setDetails?.map(detail => ({ ...detail })),
+        exerciseMaxId: banked.exerciseMaxId,
+        maxPercentage: banked.maxPercentage,
+      }
+
+      const created = await workoutService.createWorkout(newWorkout)
+      if (!created) {
+        confirmAlert('Error', 'Failed to add workout from bank')
+        return
+      }
+
+      await workoutBankService.removeBankedWorkout(banked.id)
+      setShowLibrary(false)
+      await loadWorkouts()
+    } catch (error) {
+      console.error('Error restoring banked workout:', error)
+      confirmAlert('Error', 'Failed to add workout from bank')
+    }
+  }
+
+  const handleDeleteBankedWorkout = (banked: BankedWorkout) => {
+    confirmDelete(
+      'Remove from Bank',
+      `Remove "${banked.name}" from your workout bank? This cannot be undone.`,
+      async () => {
+        const success = await workoutBankService.removeBankedWorkout(banked.id)
+        if (!success) {
+          confirmAlert('Error', 'Failed to remove banked workout')
+          return
+        }
+        await loadWorkouts()
+      },
+      () => {},
+    )
   }
 
   const handleEditWorkout = (workout: WorkoutDay) => {
@@ -214,7 +322,7 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
         return
       }
 
-      setShowExistingWorkoutSelector(false)
+      setShowLibrary(false)
       await loadWorkouts()
     } catch (error) {
       console.error('Error selecting existing workout:', error)
@@ -293,17 +401,29 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
         <View style={styles.workoutHeader}>
           <Text style={[styles.workoutName, { color: colors.text.primary }]}>{workout.name}</Text>
           <View style={styles.workoutActions}>
-            <TouchableOpacity 
+            <TouchableOpacity
               style={styles.actionButton}
               onPress={() => handleEditWorkout(workout)}
+              accessibilityLabel={`Edit ${workout.name}`}
+              accessibilityRole="button"
             >
               <Text style={[styles.editButtonText, { color: colors.primary }]}>✎</Text>
             </TouchableOpacity>
-            <TouchableOpacity 
+            <TouchableOpacity
+              style={styles.actionButton}
+              onPress={() => handleSaveWorkoutToBank(workout)}
+              accessibilityLabel={`Save ${workout.name} to bank`}
+              accessibilityRole="button"
+            >
+              <Text style={[styles.bankButtonText, { color: colors.warning }]}>★</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
               style={styles.actionButton}
               onPress={() => {
                 handleDeleteWorkout(workout)
               }}
+              accessibilityLabel={`Delete ${workout.name}`}
+              accessibilityRole="button"
             >
               <Text style={[
                 styles.deleteButtonText,
@@ -350,11 +470,11 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
             borderWidth: 1,
           },
         ]}
-        onPress={handleAddExistingWorkout}
-        accessibilityLabel="Select existing workout"
+        onPress={handleOpenLibrary}
+        accessibilityLabel="Open workout library"
         accessibilityRole="button"
       >
-        <Text style={[styles.addButtonText, { color: colors.text.primary }]}>Select Existing Workout</Text>
+        <Text style={[styles.addButtonText, { color: colors.text.primary }]}>From Library</Text>
       </TouchableOpacity>
     </View>
   )
@@ -448,55 +568,6 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
     </View>
   )
 
-  const renderExistingWorkoutSelectorModal = () => {
-    const selectableWorkouts = getSelectableExistingWorkouts()
-
-    return (
-      <View style={styles.modalOverlay}>
-        <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
-          <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
-            <Text style={[styles.modalTitle, { color: colors.text.primary }]}>
-              Select Existing Workout
-            </Text>
-            <TouchableOpacity
-              style={styles.closeButton}
-              onPress={() => setShowExistingWorkoutSelector(false)}
-              accessibilityLabel="Close workout selector"
-              accessibilityRole="button"
-            >
-              <Text style={[styles.closeButtonText, { color: colors.text.secondary }]}>✕</Text>
-            </TouchableOpacity>
-          </View>
-
-          <ScrollView style={styles.existingWorkoutList}>
-            {selectableWorkouts.length === 0 ? (
-              <Text style={[styles.emptyStateText, { color: colors.text.secondary }]}>
-                No existing workouts available
-              </Text>
-            ) : (
-              selectableWorkouts.map(workout => (
-                <TouchableOpacity
-                  key={getSyncGroupId(workout)}
-                  style={[styles.existingWorkoutItem, { backgroundColor: colors.background, borderColor: colors.border }]}
-                  onPress={() => handleSelectExistingWorkout(workout)}
-                  accessibilityLabel={`Select ${workout.name}`}
-                  accessibilityRole="button"
-                >
-                  <Text style={[styles.existingWorkoutName, { color: colors.text.primary }]}>
-                    {workout.name}
-                  </Text>
-                  <Text style={[styles.existingWorkoutDetails, { color: colors.text.secondary }]}>
-                    {workout.weight} lb • {workout.sets} sets • {workout.reps} reps
-                  </Text>
-                </TouchableOpacity>
-              ))
-            )}
-          </ScrollView>
-        </View>
-      </View>
-    )
-  }
-
   if (isLoading) {
     return (
       <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
@@ -522,7 +593,16 @@ export default function WorkoutsConfigure({ onBack }: WorkoutsConfigureProps) {
       </ScrollView>
 
       {showForm && renderFormModal()}
-      {showExistingWorkoutSelector && renderExistingWorkoutSelectorModal()}
+      {showLibrary && (
+        <WorkoutLibraryModal
+          activeWorkouts={getSelectableExistingWorkouts()}
+          bankedWorkouts={filterBankForActivePrograms(bankedWorkouts, workouts)}
+          onSelectActive={handleSelectExistingWorkout}
+          onSelectBanked={handleSelectBankedWorkout}
+          onDeleteBanked={handleDeleteBankedWorkout}
+          onClose={() => setShowLibrary(false)}
+        />
+      )}
     </View>
   )
 }
@@ -715,6 +795,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
   },
+  bankButtonText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
   disabledButton: {
     backgroundColor: '#e0e0e0',
     opacity: 0.5,
@@ -779,25 +863,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     width: '100%',
     maxHeight: '80%',
-  },
-  existingWorkoutList: {
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-  },
-  existingWorkoutItem: {
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    marginBottom: 10,
-  },
-  existingWorkoutName: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    marginBottom: 4,
-  },
-  existingWorkoutDetails: {
-    fontSize: 14,
   },
   modalHeader: {
     flexDirection: 'row',

--- a/magni/lib/models/BankedWorkout.ts
+++ b/magni/lib/models/BankedWorkout.ts
@@ -1,0 +1,121 @@
+import { SetDetail, Workout, WORKOUT_CONSTRAINTS, getSyncGroupId } from './Workout'
+
+/**
+ * A snapshot of a workout that has been "saved for later" — removed from the
+ * active program but preserved with its weights, reps, set details, notes, and
+ * exercise-max linkage so it can be restored without re-entering data.
+ *
+ * Day-specific relationships (alt/superset parents, day, dayOrder) are NOT
+ * preserved because they only make sense within a specific program day.
+ */
+export interface BankedWorkout {
+  id: string;
+  sharedWorkoutId?: string;
+  name: string;
+  weight: number;
+  sets: number;
+  reps: number;
+  notes?: string;
+  setDetails?: SetDetail[];
+  exerciseMaxId?: string;
+  maxPercentage?: number;
+  bankedAt: string;
+}
+
+export const BankedWorkoutConverter = {
+  toData: (banked: BankedWorkout): BankedWorkout => banked,
+  fromData: (data: BankedWorkout): BankedWorkout => data,
+}
+
+export class BankedWorkoutValidator {
+  static validate(banked: BankedWorkout): void {
+    if (!banked.id || banked.id.trim() === '') {
+      throw new Error('Banked workout must have an id.')
+    }
+    if (!banked.name || banked.name.trim() === '') {
+      throw new Error('Banked workout must have a name.')
+    }
+    if (!banked.bankedAt || isNaN(Date.parse(banked.bankedAt))) {
+      throw new Error('Banked workout must have a valid bankedAt timestamp.')
+    }
+    if (banked.notes && banked.notes.length > WORKOUT_CONSTRAINTS.NOTES_LENGTH_LIMIT) {
+      throw new Error(`Notes cannot exceed ${WORKOUT_CONSTRAINTS.NOTES_LENGTH_LIMIT} characters.`)
+    }
+    if (banked.weight > WORKOUT_CONSTRAINTS.WEIGHT_LIMIT) {
+      throw new Error(`Weight cannot exceed ${WORKOUT_CONSTRAINTS.WEIGHT_LIMIT}.`)
+    }
+    if (banked.reps > WORKOUT_CONSTRAINTS.REPS_LIMIT) {
+      throw new Error(`Reps cannot exceed ${WORKOUT_CONSTRAINTS.REPS_LIMIT}.`)
+    }
+    if (banked.sets > WORKOUT_CONSTRAINTS.SETS_LIMIT) {
+      throw new Error(`Sets cannot exceed ${WORKOUT_CONSTRAINTS.SETS_LIMIT}.`)
+    }
+    if (banked.setDetails) {
+      for (const detail of banked.setDetails) {
+        if (detail.weight > WORKOUT_CONSTRAINTS.WEIGHT_LIMIT) {
+          throw new Error(`Weight cannot exceed ${WORKOUT_CONSTRAINTS.WEIGHT_LIMIT}.`)
+        }
+        if (detail.reps > WORKOUT_CONSTRAINTS.REPS_LIMIT) {
+          throw new Error(`Reps cannot exceed ${WORKOUT_CONSTRAINTS.REPS_LIMIT}.`)
+        }
+      }
+    }
+  }
+
+  static hasSetDetails(banked: BankedWorkout): boolean {
+    return !!(banked.setDetails && banked.setDetails.length > 0)
+  }
+}
+
+/**
+ * The sync group identifier for a banked workout — same idea as
+ * `getSyncGroupId` for Workout, but defined here so BankedWorkout doesn't
+ * need to be widened to a full Workout shape.
+ */
+export function getBankedSyncGroupId(banked: BankedWorkout): string {
+  return banked.sharedWorkoutId ?? banked.id
+}
+
+/**
+ * Returns the subset of `banked` whose sync group is NOT currently represented
+ * by any active program workout. Used to keep the workout library from showing
+ * the same exercise twice — once as "Program" and once as "Bank" — when a user
+ * banked an exercise that is still scheduled in another day. Once all active
+ * copies are removed, the banked entry surfaces in the library again.
+ */
+export function filterBankForActivePrograms(
+  banked: BankedWorkout[],
+  activeWorkouts: Workout[],
+): BankedWorkout[] {
+  const activeSyncGroups = new Set(activeWorkouts.map(getSyncGroupId))
+  return banked.filter(entry => !activeSyncGroups.has(getBankedSyncGroupId(entry)))
+}
+
+/**
+ * Build a BankedWorkout snapshot from any Workout-shaped value.
+ * Day-specific fields are stripped; weights/reps/setDetails/notes/exerciseMax
+ * are preserved by value (deep-copied where mutable).
+ */
+export function bankedWorkoutFromWorkout(
+  workout: Workout,
+  options?: { id?: string; bankedAt?: Date | string },
+): BankedWorkout {
+  const id = options?.id ?? `bank-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+  const bankedAt = typeof options?.bankedAt === 'string'
+    ? options.bankedAt
+    : (options?.bankedAt ?? new Date()).toISOString()
+
+  return {
+    id,
+    sharedWorkoutId: workout.sharedWorkoutId ?? workout.id,
+    name: workout.name,
+    weight: workout.weight,
+    sets: workout.sets,
+    reps: workout.reps,
+    notes: workout.notes,
+    setDetails: workout.setDetails?.map(detail => ({ ...detail })),
+    exerciseMaxId: workout.exerciseMaxId,
+    maxPercentage: workout.maxPercentage,
+    bankedAt,
+  }
+}

--- a/magni/lib/services/WorkoutBankService.ts
+++ b/magni/lib/services/WorkoutBankService.ts
@@ -1,0 +1,91 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  BankedWorkout,
+  BankedWorkoutValidator,
+  bankedWorkoutFromWorkout,
+} from '../models/BankedWorkout'
+import { Workout } from '../models/Workout'
+
+const WORKOUT_BANK_STORAGE_KEY = 'workout_bank'
+
+class WorkoutBankService {
+  private static instance: WorkoutBankService
+
+  private constructor() {}
+
+  static getInstance(): WorkoutBankService {
+    if (!WorkoutBankService.instance) {
+      WorkoutBankService.instance = new WorkoutBankService()
+    }
+    return WorkoutBankService.instance
+  }
+
+  /**
+   * Returns all banked workouts, sorted most-recently-banked first.
+   */
+  async getBankedWorkouts(): Promise<BankedWorkout[]> {
+    try {
+      const json = await AsyncStorage.getItem(WORKOUT_BANK_STORAGE_KEY)
+      if (!json) return []
+
+      const banked: BankedWorkout[] = JSON.parse(json)
+      return [...banked].sort((a, b) => {
+        const aTime = Date.parse(a.bankedAt) || 0
+        const bTime = Date.parse(b.bankedAt) || 0
+        return bTime - aTime
+      })
+    } catch (error) {
+      console.error('Error getting banked workouts:', error)
+      return []
+    }
+  }
+
+  /**
+   * Persist a snapshot of `workout` into the bank. If a banked entry with the
+   * same `sharedWorkoutId` already exists, it is replaced (keeps the bank from
+   * filling up with stale duplicates of the same exercise).
+   */
+  async bankWorkout(workout: Workout): Promise<boolean> {
+    try {
+      const snapshot = bankedWorkoutFromWorkout(workout)
+      BankedWorkoutValidator.validate(snapshot)
+
+      const existing = await this.getBankedWorkouts()
+      const filtered = existing.filter(
+        entry => entry.sharedWorkoutId !== snapshot.sharedWorkoutId,
+      )
+      const next = [snapshot, ...filtered]
+
+      await AsyncStorage.setItem(WORKOUT_BANK_STORAGE_KEY, JSON.stringify(next))
+      return true
+    } catch (error) {
+      console.error('Error banking workout:', error)
+      return false
+    }
+  }
+
+  async removeBankedWorkout(id: string): Promise<boolean> {
+    try {
+      const existing = await this.getBankedWorkouts()
+      const next = existing.filter(entry => entry.id !== id)
+      await AsyncStorage.setItem(WORKOUT_BANK_STORAGE_KEY, JSON.stringify(next))
+      return true
+    } catch (error) {
+      console.error('Error removing banked workout:', error)
+      return false
+    }
+  }
+
+  async clearBank(): Promise<boolean> {
+    try {
+      await AsyncStorage.setItem(WORKOUT_BANK_STORAGE_KEY, JSON.stringify([]))
+      return true
+    } catch (error) {
+      console.error('Error clearing workout bank:', error)
+      return false
+    }
+  }
+}
+
+export const workoutBankService = WorkoutBankService.getInstance()
+export { WORKOUT_BANK_STORAGE_KEY }

--- a/magni/lib/services/WorkoutService.ts
+++ b/magni/lib/services/WorkoutService.ts
@@ -83,6 +83,28 @@ class WorkoutService {
   }
 
   /**
+   * Removes every workout whose id is in `ids` in a single read/write. Use this instead of
+   * multiple parallel `removeWorkout` calls — concurrent removes each re-read and re-write
+   * the full list, so the last write wins and drops other removals (lost update bug).
+   */
+  async removeWorkoutsByIds(ids: string[]): Promise<boolean> {
+    try {
+      if (ids.length === 0) {
+        return true
+      }
+      const idSet = new Set(ids)
+      const existingWorkouts = await this.getWorkouts()
+      const filteredWorkouts = existingWorkouts.filter(workout => !idSet.has(workout.id))
+
+      await AsyncStorage.setItem(WORKOUT_STORAGE_KEY, JSON.stringify(filteredWorkouts))
+      return true
+    } catch (error) {
+      console.error('Error removing workouts:', error)
+      return false
+    }
+  }
+
+  /**
    * When a 1RM changes, keep programmed % the same and refresh stored absolute weights.
    * `previousMaxWeight` is the max before the edit (used to recover % for per-set and legacy rows).
    */


### PR DESCRIPTION
## Summary

Adds a **workout bank** so users can park exercises (with weights, reps, set details, and max linkage) off the program and restore them later from a unified **library** with search and Program/Bank/All filters.

## What changed

- **Persistence:** `BankedWorkout` model + `WorkoutBankService` (AsyncStorage `workout_bank`); snapshots keyed by sync group with replace-on-duplicate.
- **Configure workouts:** ★ **Save to bank** (confirms scope; removes **all** instances in the same `sharedWorkoutId` group so multi-day linked copies stay consistent). **From library** replaces “select existing” with search + source chips + optional remove-from-bank.
- **Library UX:** `WorkoutLibraryModal` — badges aligned with the delete column; tighter right padding on **Bank** vs **Program** rows.
- **Correctness:** `filterBankForActivePrograms` hides a bank row while that exercise still exists anywhere in the program (avoids duplicate Program + Bank rows). **`removeWorkoutsByIds`** fixes a lost-update bug from parallel `removeWorkout` + `Promise.all`.

## Tests

- `BankedWorkout` / `filterBankForActivePrograms` / `bankedWorkoutFromWorkout`
- `WorkoutBankService`
- `WorkoutLibraryModal` interactions
- `WorkoutService.removeWorkoutsByIds`